### PR TITLE
fix: increase Helm install timeout to prevent Prometheus installation failures

### DIFF
--- a/internal/components/helm.go
+++ b/internal/components/helm.go
@@ -273,7 +273,7 @@ func (h *HelmInstaller) install(ctx context.Context, actionConfig *action.Config
 	client.ReleaseName = release.Name
 	client.CreateNamespace = true
 	client.Wait = true
-	client.Timeout = 10 * time.Minute
+	client.Timeout = 15 * time.Minute // Increased from 10 to 15 minutes for slow environments
 	client.Version = release.Version
 	client.SkipCRDs = true // Skip CRDs - they may be pre-installed by installer script
 	client.Replace = allowNameReuse
@@ -329,7 +329,7 @@ func (h *HelmInstaller) upgradeWithForce(ctx context.Context, actionConfig *acti
 	client := action.NewUpgrade(actionConfig)
 	client.Namespace = release.Namespace
 	client.Wait = true
-	client.Timeout = 10 * time.Minute
+	client.Timeout = 15 * time.Minute // Increased from 10 to 15 minutes for slow environments
 	client.Version = release.Version
 	client.Install = true
 	client.Force = true
@@ -380,7 +380,7 @@ func (h *HelmInstaller) upgrade(ctx context.Context, actionConfig *action.Config
 	client := action.NewUpgrade(actionConfig)
 	client.Namespace = release.Namespace
 	client.Wait = true
-	client.Timeout = 10 * time.Minute
+	client.Timeout = 15 * time.Minute // Increased from 10 to 15 minutes for slow environments
 	client.Version = release.Version
 
 	// Determine chart reference for locating


### PR DESCRIPTION
## Problem
The Prometheus helm installation was timing out after 10 minutes with the error:
```
failed to install Prometheus: helm install failed: context deadline exceeded
```

This occurs in environments with:
- Slow network connections
- Limited resources (CPU/memory)
- High cluster load
- Slow container image pulls

## Solution
Increased the Helm operation timeout from 10 to 15 minutes for:
- `install()` - fresh installations
- `upgrade()` - upgrades
- `upgradeWithForce()` - forced upgrades for recovery

## Changes
- Modified `internal/components/helm.go` to increase `client.Timeout` from `10 * time.Minute` to `15 * time.Minute`
- Added comments explaining the timeout increase

## Testing
- Prometheus installation should now complete successfully in slower environments
- No impact on fast environments (will just complete earlier)
- Timeout is still reasonable to catch actual failures

## Impact
- ✅ Fixes timeout errors during Prometheus installation
- ✅ Improves reliability in resource-constrained environments
- ✅ No breaking changes
- ✅ Backward compatible