### PR TITLE
feat: Update installation instructions with additional script options

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -559,13 +559,21 @@ If you need to remove the PipeOps Agent from your system:
 
 === "Script Installation"
 
-    **Using the uninstall command**:
+    **Using the uninstall script (recommended)**:
     ```bash
-    # Uninstall agent and cleanup
-    sudo pipeops-agent uninstall
+    curl -fsSL https://raw.githubusercontent.com/PipeOpsHQ/pipeops-k8-agent/main/scripts/uninstall.sh | bash
+    ```
 
-    # Remove all data (optional)
-    sudo pipeops-agent uninstall --purge-data
+    **Include optional flags via environment variables**:
+    ```bash
+    # Remove the agent but keep PVC data
+    KEEP_DATA=true curl -fsSL https://raw.githubusercontent.com/PipeOpsHQ/pipeops-k8-agent/main/scripts/uninstall.sh | bash
+
+    # Remove the agent and bundled k3s install
+    UNINSTALL_K3S=true curl -fsSL https://raw.githubusercontent.com/PipeOpsHQ/pipeops-k8-agent/main/scripts/uninstall.sh | bash
+
+    # Skip interactive prompts for automation
+    FORCE=true curl -fsSL https://raw.githubusercontent.com/PipeOpsHQ/pipeops-k8-agent/main/scripts/uninstall.sh | bash
     ```
 
     **Manual removal**:
@@ -656,15 +664,15 @@ If you need to remove the PipeOps Agent from your system:
 Remove only specific components:
 
 ```bash
-# Remove only monitoring stack (keep agent)
-pipeops-agent monitoring uninstall
+# Remove the agent but keep PVC data
+KEEP_DATA=true curl -fsSL https://raw.githubusercontent.com/PipeOpsHQ/pipeops-k8-agent/main/scripts/uninstall.sh | bash
 
-# Remove only the agent (keep Kubernetes cluster)
-pipeops-agent uninstall --keep-cluster
+# Remove the agent and bundled k3s install
+UNINSTALL_K3S=true curl -fsSL https://raw.githubusercontent.com/PipeOpsHQ/pipeops-k8-agent/main/scripts/uninstall.sh | bash
 
-# Remove configuration but keep logs
+# Remove configuration while leaving logs for auditing
 sudo rm -rf /etc/pipeops
-# Keep: /var/log/pipeops
+# Logs remain in /var/log/pipeops
 ```
 
 ### Cleanup Verification


### PR DESCRIPTION
This pull request updates the documentation for uninstalling the PipeOps Agent to recommend and clarify the use of the uninstall script, introduces environment variable flags for more flexible uninstallation, and provides clearer examples for removing specific components.

Improvements to uninstall instructions:

* Changed the recommended uninstall method to use the `uninstall.sh` script via `curl`, replacing the previous command-line tool approach for consistency and reliability.
* Added examples of using environment variable flags (`KEEP_DATA`, `UNINSTALL_K3S`, `FORCE`) to customize the uninstall process, such as keeping PVC data, removing bundled k3s, or skipping prompts for automation.

Clarification and enhancement of component removal examples:

* Updated examples for removing specific components to use the uninstall script with relevant flags, replacing older agent CLI commands for better clarity and alignment with the recommended uninstall process.
* Clarified manual removal instructions, emphasizing how to remove configuration files while retaining logs for auditing purposes.