### PR TITLE
fix: use constant format string in fmt.Errorf

### DIFF
--- a/internal/components/gateway.go
+++ b/internal/components/gateway.go
@@ -440,7 +440,7 @@ func (gi *GatewayInstaller) validate(opts GatewayOptions) error {
     }
 
     if len(problems) > 0 {
-        return fmt.Errorf(strings.Join(problems, "; "))
+        return fmt.Errorf("%s", strings.Join(problems, "; "))
     }
     return nil
 }


### PR DESCRIPTION
This pull request includes a minor change to the error formatting in the `validate` function of `internal/components/gateway.go`. The update clarifies the error message construction by explicitly formatting the joined problem strings.

* Updated the error return in `validate` to use `fmt.Errorf("%s", ...)` instead of `fmt.Errorf(...)`, ensuring the error message is formatted as a string.