### PR TITLE
refactor: remove Gateway API/Istio installation from shell script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -395,6 +395,81 @@ create_agent_config() {
 # The agent now handles Gateway API CRDs, Istio base, and Istiod installation
 # similar to how it manages Prometheus, Loki, and other components.
 # This provides better consistency and allows for dynamic configuration.
+#
+# Function to install Gateway API and Istio for TCP/UDP routing (DEPRECATED - now handled by Go agent)
+# install_gateway_api_stack() {
+#     # Only install on server nodes
+#     if [ "$NODE_TYPE" = "agent" ]; then
+#         print_status "Skipping Gateway API installation on worker node"
+#         return 0
+#     fi
+#     
+#     # Check if Gateway API installation is enabled
+#     if [ "$INSTALL_GATEWAY_API" != "true" ]; then
+#         print_status "Gateway API installation disabled (set INSTALL_GATEWAY_API=true to enable TCP/UDP routing)"
+#         return 0
+#     fi
+# 
+#     print_status "Installing Gateway API and Istio for TCP/UDP routing..."
+# 
+#     ensure_kubeconfig_env
+#     
+#     local KUBECTL=$(get_kubectl)
+#     
+#     # Check if Helm is installed
+#     if ! command_exists helm; then
+#         print_status "Installing Helm..."
+#         curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+#         print_success "Helm installed"
+#     fi
+#     
+#     # Install Gateway API experimental CRDs
+#     print_status "Installing Gateway API experimental CRDs..."
+#     GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.3.0}"
+#     if $KUBECTL apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml" >/dev/null 2>&1; then
+#         print_success "Gateway API CRDs installed"
+#     else
+#         print_warning "Gateway API CRDs may already be installed or failed to install"
+#     fi
+#     
+#     # Add Istio Helm repository
+#     print_status "Adding Istio Helm repository..."
+#     helm repo add istio https://istio-release.storage.googleapis.com/charts 2>/dev/null || true
+#     helm repo update >/dev/null 2>&1
+#     
+#     # Create istio-system namespace
+#     $KUBECTL create namespace istio-system --dry-run=client -o yaml | $KUBECTL apply -f - >/dev/null 2>&1
+#     
+#     # Install Istio base (CRDs)
+#     print_status "Installing Istio base components..."
+#     if helm list -n istio-system 2>/dev/null | grep -q "istio-base"; then
+#         print_status "Istio base already installed, upgrading..."
+#         helm upgrade istio-base istio/base -n istio-system --wait >/dev/null 2>&1
+#     else
+#         helm install istio-base istio/base -n istio-system --wait >/dev/null 2>&1
+#     fi
+#     
+#     # Install Istiod with Gateway API alpha support
+#     print_status "Installing Istiod with Gateway API support..."
+#     if helm list -n istio-system 2>/dev/null | grep -q "istiod"; then
+#         print_status "Istiod already installed, upgrading..."
+#         helm upgrade istiod istio/istiod -n istio-system \
+#             --set pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=true \
+#             --wait >/dev/null 2>&1
+#     else
+#         helm install istiod istio/istiod -n istio-system \
+#             --set pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=true \
+#             --wait >/dev/null 2>&1
+#     fi
+#     
+#     if [ $? -eq 0 ]; then
+#         print_success "Gateway API and Istio installed successfully"
+#         print_status "TCPRoute and UDPRoute support enabled"
+#     else
+#         print_warning "Gateway API/Istio installation may have encountered issues"
+#         return 1
+#     fi
+# }
 
 # Function to install monitoring components (Prometheus, Loki, Grafana, OpenCost)
 install_monitoring_stack() {


### PR DESCRIPTION
Gateway API CRDs and Istio (base/istiod) installation should be handled by the Go agent, just like other components (Prometheus, Loki, etc). This provides better consistency and dynamic configuration.