### PR TITLE
fix: prioritize local environment detection before metadata service

### DIFF
--- a/pkg/cloud/region.go
+++ b/pkg/cloud/region.go
@@ -42,10 +42,11 @@ func DetectRegion(ctx context.Context, k8sClient kubernetes.Interface, logger *l
 	logger.Info("Detecting cloud provider and region...")
 
 	// Try detection methods in order of reliability
+	// Check nodes first (most reliable), then local/dev environments, then metadata service
 	detectors := []func(context.Context, kubernetes.Interface, *logrus.Logger) (RegionInfo, bool){
 		detectFromNodes,
-		detectFromMetadataService,
 		detectFromEnvironment,
+		detectFromMetadataService,
 	}
 
 	for _, detector := range detectors {


### PR DESCRIPTION
- Reorder detection methods to check local/dev environments before metadata service
- Prevents Azure metadata service from interfering with test expectations
- Fixes TestDetectLocalEnvironments and TestDetectRegionInfo test failures