### PR TITLE
Fix region detection order to prioritize local environments

### DIFF
--- a/pkg/cloud/region.go
+++ b/pkg/cloud/region.go
@@ -45,11 +45,12 @@ func DetectRegion(ctx context.Context, k8sClient kubernetes.Interface, logger *l
 	geoIP := DetectGeoIP(ctx, logger)
 
 	// Try detection methods in order of reliability
-	// Check nodes first (most reliable), then metadata service, then local/dev environments
+	// Check nodes first (most reliable), then local/dev environments, then metadata service
+	// We check local/dev before metadata to avoid false positives when running tests on CI servers
 	detectors := []func(context.Context, kubernetes.Interface, *logrus.Logger, *GeoIPInfo) (RegionInfo, bool){
 		detectFromNodes,
-		detectFromMetadataService,
 		detectFromEnvironment,
+		detectFromMetadataService,
 	}
 
 	for _, detector := range detectors {


### PR DESCRIPTION
- Reorder detection methods to check local/dev environments before metadata service
- Prevents false positives when running tests on CI servers (e.g., Azure)
- Tests now consistently pass for K3s, kind, minikube, Docker Desktop, and bare-metal clusters
- GeoIP-based region detection works correctly for on-premises installations