### PR TITLE
fix: Update permissions for autoscaling resources in agent and minikube-rbac deployments

### DIFF
--- a/deployments/agent.yaml
+++ b/deployments/agent.yaml
@@ -112,7 +112,7 @@ rules:
 - apiGroups: ["autoscaling"]
   resources:
     - "horizontalpodautoscalers"
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 # Admission webhooks
 - apiGroups: ["admissionregistration.k8s.io"]

--- a/deployments/minikube-rbac.yaml
+++ b/deployments/minikube-rbac.yaml
@@ -65,7 +65,7 @@ rules:
 - apiGroups: ["autoscaling"]
   resources:
     - "horizontalpodautoscalers"
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 # Admission webhooks
 - apiGroups: ["admissionregistration.k8s.io"]

--- a/helm/pipeops-agent/templates/clusterrole.yaml
+++ b/helm/pipeops-agent/templates/clusterrole.yaml
@@ -121,6 +121,12 @@ rules:
     - "udproutes"
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
+# Autoscaling resources
+- apiGroups: ["autoscaling"]
+  resources:
+    - "horizontalpodautoscalers"
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
 # Node operations
 - apiGroups: [""]
   resources:


### PR DESCRIPTION
This pull request updates Kubernetes RBAC (Role-Based Access Control) configurations to grant broader permissions on the `horizontalpodautoscalers` resource in the `autoscaling` API group. The changes ensure that the agent has full management capabilities over HorizontalPodAutoscalers, including creation, modification, and deletion, across different deployment environments.

**RBAC permission updates for HorizontalPodAutoscalers:**

* Expanded the allowed verbs for `horizontalpodautoscalers` in `deployments/agent.yaml` to include `create`, `update`, `patch`, and `delete`, in addition to the existing `get`, `list`, and `watch` permissions.
* Made the same expanded permissions change in `deployments/minikube-rbac.yaml` for consistency in local development environments.
* Added a new rule for `horizontalpodautoscalers` with full CRUD permissions in the Helm chart's `clusterrole.yaml`, ensuring these permissions are also available when deploying via Helm.