### PR TITLE
feat: Add enableIngressSync to agent config and update deployment info extraction

### DIFF
--- a/helm/pipeops-agent/templates/configmap.yaml
+++ b/helm/pipeops-agent/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
       {{- end }}
       name: {{ .Values.agent.name | default "pipeops-agent" | quote }}
       cluster_name: {{ .Values.agent.cluster.name | quote }}
+      enable_ingress_sync: {{ .Values.agent.enableIngressSync | default true }}
       labels:
         {{- toYaml .Values.agent.labels | nindent 8 }}
     

--- a/helm/pipeops-agent/values.yaml
+++ b/helm/pipeops-agent/values.yaml
@@ -155,6 +155,13 @@ agent:
   # Set to false for existing clusters that already have these components
   autoInstallComponents: false  # Default: false (do not auto-install)
   
+  # Ingress sync configuration
+  # When true, the agent monitors PipeOps-managed ingresses and registers routes with the control plane
+  # The gateway automatically detects cluster type and chooses optimal routing mode:
+  #   - Direct routing: For public clusters with LoadBalancer (traffic goes directly to LB IP)
+  #   - Tunnel routing: For private clusters (traffic routes through PipeOps gateway)
+  enableIngressSync: true  # Default: true (enabled by default)
+  
   # Gateway configuration for TCP/UDP port exposure
   # PipeOps uses Kubernetes Gateway API with Istio controller by default
   # 

--- a/internal/ingress/client.go
+++ b/internal/ingress/client.go
@@ -134,6 +134,8 @@ type RegisterRouteRequest struct {
 	Annotations    map[string]string `json:"annotations,omitempty"`
 	PublicEndpoint string            `json:"public_endpoint,omitempty"` // For direct routing
 	RoutingMode    string            `json:"routing_mode,omitempty"`    // "direct" or "tunnel"
+	DeploymentID   string            `json:"deployment_id,omitempty"`   // PipeOps deployment ID
+	DeploymentName string            `json:"deployment_name,omitempty"` // PipeOps deployment name
 }
 
 // SyncIngressesRequest is the bulk sync request for all ingresses

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -380,15 +380,18 @@ create_agent_config() {
     # Create namespace
     $KUBECTL create namespace "$NAMESPACE" --dry-run=client -o yaml | $KUBECTL apply -f -
 
-    # Create secret with configuration
+    # Delete existing secret if it exists to ensure clean update
+    $KUBECTL delete secret pipeops-agent-config --namespace="$NAMESPACE" --ignore-not-found=true
+    
+    # Create secret with configuration (including new fields)
     $KUBECTL create secret generic pipeops-agent-config \
         --namespace="$NAMESPACE" \
         --from-literal=PIPEOPS_API_URL="$PIPEOPS_API_URL" \
         --from-literal=PIPEOPS_TOKEN="$AGENT_TOKEN" \
         --from-literal=PIPEOPS_CLUSTER_NAME="$CLUSTER_NAME" \
-        --dry-run=client -o yaml | $KUBECTL apply -f -
+        --from-literal=ENABLE_INGRESS_SYNC="true"
 
-    print_success "Agent configuration created"
+    print_success "Agent configuration created/updated"
 }
 
 # NOTE: Gateway API and Istio installation has been moved to the Go agent


### PR DESCRIPTION
This pull request introduces improvements to how the PipeOps agent identifies and registers deployment information for managed ingresses, as well as enhancements to configuration and installation scripts. The most significant changes include extracting deployment metadata from ingress annotations, updating the agent’s configuration to support ingress sync, and adding robust unit tests for the new logic.

**Ingress deployment metadata extraction and registration:**

* Added logic in `internal/ingress/watcher.go` to extract deployment ID and name from ingress annotations using a prioritized approach: explicit annotations, derived from owner/environment, or parsed from the hostname. This ensures more accurate route registration with the control plane.
* Updated the `RegisterRouteRequest` struct in `internal/ingress/client.go` to include `DeploymentID` and `DeploymentName` fields, allowing this metadata to be sent to the control plane.
* Modified the ingress event handler to extract and include deployment information when registering routes. [[1]](diffhunk://#diff-b0c4c1ff30f6e49b765e3bc4c09ae5645fab856f6696c2c54d228e36230a0826R206-R208) [[2]](diffhunk://#diff-b0c4c1ff30f6e49b765e3bc4c09ae5645fab856f6696c2c54d228e36230a0826R222-R223)

**Configuration and installation enhancements:**

* Added the `enableIngressSync` configuration option (default: true) to the Helm chart (`helm/pipeops-agent/values.yaml` and `helm/pipeops-agent/templates/configmap.yaml`) and ensured the install script sets this value in the agent secret. This allows enabling or disabling ingress syncing via configuration. [[1]](diffhunk://#diff-ac86516573439b99b9bf02d01bb7b1b2960861d56970c80a845db93f22801f94R158-R164) [[2]](diffhunk://#diff-e2ab79d1d44dc48b45c191fffcfb756e205dd88c17cce88eb42bc3975adb2504R18) [[3]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccL383-R394)

**Testing improvements:**

* Introduced comprehensive unit tests for the deployment info extraction logic in `internal/ingress/watcher_test.go`, covering various annotation and hostname scenarios.

These changes collectively improve the agent’s ability to track and report deployment context for managed ingresses, provide more flexible configuration, and ensure correctness through testing.