### PR TITLE
chore: Add non-resource URLs for API proxy and gateway access

### DIFF
--- a/deployments/agent.yaml
+++ b/deployments/agent.yaml
@@ -177,6 +177,25 @@ rules:
     - "serviceaccounts"
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
+# Non-resource URLs (for API proxy and gateway access)
+- nonResourceURLs:
+    - "/"
+    - "/api"
+    - "/api/*"
+    - "/apis"
+    - "/apis/*"
+    - "/healthz"
+    - "/healthz/*"
+    - "/livez"
+    - "/livez/*"
+    - "/readyz"
+    - "/readyz/*"
+    - "/metrics"
+    - "/version"
+    - "/openapi"
+    - "/openapi/*"
+  verbs: ["get", "post", "put", "patch", "delete"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployments/minikube-rbac.yaml
+++ b/deployments/minikube-rbac.yaml
@@ -104,6 +104,25 @@ rules:
     - "poddisruptionbudgets"
     - "podsecuritypolicies"
   verbs: ["get", "list", "watch", "use"]
+
+# Non-resource URLs (for API proxy and gateway access)
+- nonResourceURLs:
+    - "/"
+    - "/api"
+    - "/api/*"
+    - "/apis"
+    - "/apis/*"
+    - "/healthz"
+    - "/healthz/*"
+    - "/livez"
+    - "/livez/*"
+    - "/readyz"
+    - "/readyz/*"
+    - "/metrics"
+    - "/version"
+    - "/openapi"
+    - "/openapi/*"
+  verbs: ["get", "post", "put", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/pipeops-agent/templates/clusterrole.yaml
+++ b/helm/pipeops-agent/templates/clusterrole.yaml
@@ -139,4 +139,23 @@ rules:
     - "pods/exec"
     - "pods/portforward"
   verbs: ["create"]
+
+# Non-resource URLs (for API proxy and gateway access)
+- nonResourceURLs:
+    - "/"
+    - "/api"
+    - "/api/*"
+    - "/apis"
+    - "/apis/*"
+    - "/healthz"
+    - "/healthz/*"
+    - "/livez"
+    - "/livez/*"
+    - "/readyz"
+    - "/readyz/*"
+    - "/metrics"
+    - "/version"
+    - "/openapi"
+    - "/openapi/*"
+  verbs: ["get", "post", "put", "patch", "delete"]
 {{- end }}


### PR DESCRIPTION
This pull request updates the Kubernetes RBAC (Role-Based Access Control) configurations to grant agents and services explicit permissions for accessing various non-resource URLs. These changes are applied across deployment and Helm chart configuration files, ensuring that components like API proxies and gateways can interact with essential Kubernetes endpoints for health checks, metrics, and API discovery.

Key RBAC permission updates:

**Non-resource URL access:**

* Added `nonResourceURLs` rules to `deployments/agent.yaml`, `deployments/minikube-rbac.yaml`, and `helm/pipeops-agent/templates/clusterrole.yaml` to allow HTTP verbs (`get`, `post`, `put`, `patch`, `delete`) on critical Kubernetes endpoints such as `/api`, `/apis`, `/healthz`, `/livez`, `/readyz`, `/metrics`, `/version`, and `/openapi`. This enables agents to perform necessary operations for API proxying, gateway access, and health monitoring. [[1]](diffhunk://#diff-171fb0b54fd918a99fc5c8d0d55d7303bde5f97883be2e42c7358604e0c3db2fR180-R198) [[2]](diffhunk://#diff-9b8beb1cadfde071bbb1cb75068a5e2758b626264c48999df6e8138f0c0e64e5R107-R125) [[3]](diffhunk://#diff-812c080c0576e8af6ba74f61768973bf651487a1220fbb5b03c1237f9457cd1cR142-R160)