### PR TITLE
feat: Add cert-manager configuration and auto-create default ClusterIssuers

### DIFF
--- a/deployments/cert-manager-clusterissuers.yaml
+++ b/deployments/cert-manager-clusterissuers.yaml
@@ -1,0 +1,79 @@
+# Default ClusterIssuers for PipeOps cert-manager integration
+# These are automatically created when cert-manager is installed by the agent
+# You can also apply them manually with: kubectl apply -f cert-manager-clusterissuers.yaml
+
+---
+# ClusterIssuer for Let's Encrypt production
+# Use annotation: cert-manager.io/cluster-issuer: "letsencrypt-prod"
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # Production Let's Encrypt ACME server
+    server: https://acme-v02.api.letsencrypt.org/directory
+    
+    # Email for Let's Encrypt notifications (certificate expiry, etc.)
+    # TODO: Update this with your actual admin email
+    email: admin@pipeops.io
+    
+    # Secret to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    
+    # HTTP-01 challenge solver using NGINX Ingress Controller
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+
+---
+# ClusterIssuer for Let's Encrypt production (alias)
+# Use annotation: cert-manager.io/cluster-issuer: "letsencrypt-production"
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    # Production Let's Encrypt ACME server
+    server: https://acme-v02.api.letsencrypt.org/directory
+    
+    # Email for Let's Encrypt notifications
+    # TODO: Update this with your actual admin email
+    email: admin@pipeops.io
+    
+    # Secret to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-production
+    
+    # HTTP-01 challenge solver using NGINX Ingress Controller
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+
+---
+# Optional: ClusterIssuer for Let's Encrypt staging (for testing)
+# Use annotation: cert-manager.io/cluster-issuer: "letsencrypt-staging"
+# Uncomment to enable:
+#
+# apiVersion: cert-manager.io/v1
+# kind: ClusterIssuer
+# metadata:
+#   name: letsencrypt-staging
+# spec:
+#   acme:
+#     # Staging Let's Encrypt ACME server (use for testing)
+#     server: https://acme-staging-v02.api.letsencrypt.org/directory
+#     
+#     email: admin@pipeops.io
+#     
+#     privateKeySecretRef:
+#       name: letsencrypt-staging
+#     
+#     solvers:
+#     - http01:
+#         ingress:
+#           class: nginx

--- a/internal/components/defaults.go
+++ b/internal/components/defaults.go
@@ -58,6 +58,15 @@ func DefaultMonitoringStack() *MonitoringStack {
 			StorageSize:       "5Gi", // Default storage size for Grafana
 			EnablePersistence: true,  // Enable persistent storage
 		},
+		CertManager: &CertManagerConfig{
+			Enabled:      true,
+			Namespace:    "cert-manager",
+			ReleaseName:  "cert-manager",
+			ChartRepo:    "https://charts.jetstack.io",
+			ChartName:    "jetstack/cert-manager",
+			ChartVersion: "v1.13.3", // Latest stable version
+			InstallCRDs:  true,       // Install CRDs automatically
+		},
 	}
 }
 


### PR DESCRIPTION
This pull request introduces integrated support for automatic TLS certificate management using cert-manager. It adds the ability to automatically install cert-manager (via Helm), configure its resources, and set up default Let's Encrypt ClusterIssuers for production environments. The changes are primarily focused on making secure TLS setup easier and more automated within the monitoring stack.

**Cert-manager integration and automation:**

* Added a new `CertManagerConfig` struct and corresponding field in `MonitoringStack` to manage cert-manager installation and configuration, including Helm chart details and CRD installation. (`internal/components/manager.go` [[1]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R29) [[2]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R95-R105); `internal/components/defaults.go` [[3]](diffhunk://#diff-8417be354868d4791540e17a94ef8939626bcbc741593c7f13f7358b15f1577dR61-R69)
* Updated the monitoring stack manager to automatically install cert-manager if enabled, with resource requests/limits and webhook/CA injector configuration. (`internal/components/manager.go` [[1]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R166-R172) [[2]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R995-R1239)
* Implemented logic to check if cert-manager is already installed, wait for the webhook to be ready, and handle installation errors gracefully. (`internal/components/manager.go` [internal/components/manager.goR995-R1239](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R995-R1239))

**Automatic ClusterIssuer setup:**

* Added code to create default Let's Encrypt ClusterIssuers (`letsencrypt-prod` and `letsencrypt-production`) after cert-manager is installed and ready, enabling automatic TLS for ingresses. (`internal/components/manager.go` [internal/components/manager.goR995-R1239](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R995-R1239))
* Provided a YAML manifest for the default ClusterIssuers, including an optional commented-out staging issuer for testing. (`deployments/cert-manager-clusterissuers.yaml` [deployments/cert-manager-clusterissuers.yamlR1-R79](diffhunk://#diff-fa3f13a78437380cb93ea20b9d9cf9090251420050e2934308739826b8f001feR1-R79))