### PR TITLE
feat: Add functionality to proxy requests to application services instead of Kubernetes API

### DIFF
--- a/internal/controlplane/types.go
+++ b/internal/controlplane/types.go
@@ -130,6 +130,11 @@ type ProxyRequest struct {
 
 	SupportsStreaming bool          `json:"supports_streaming"`
 	bodyStream        io.ReadCloser `json:"-"`
+
+	// Route context for proxying to application services (not K8s API)
+	Namespace   string `json:"namespace"`
+	ServiceName string `json:"service_name"`
+	ServicePort int32  `json:"service_port"`
 }
 
 // ProxyResponse represents the response returned to the control plane after fulfilling a proxy request

--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -1067,6 +1067,13 @@ func (c *WebSocketClient) parseProxyRequest(msg *WebSocketMessage) (*ProxyReques
 		req.RateLimitBps = rateLimit
 	}
 
+	// Parse route context for proxying to application services
+	req.Namespace = getString("namespace")
+	req.ServiceName = getString("service_name")
+	if servicePort, ok := payload["service_port"].(float64); ok {
+		req.ServicePort = int32(servicePort)
+	}
+
 	return req, nil
 }
 


### PR DESCRIPTION
This pull request adds support for proxying requests directly to application services within the Kubernetes cluster, in addition to the existing Kubernetes API proxying. The changes introduce a new route context to the proxy request structure, enabling the agent to route requests based on service name, namespace, and port. The implementation includes a dedicated proxying function and updates logging to reflect the new routing information.

**Application Service Proxying:**

* Added a new `proxyToService` function in `internal/agent/agent.go` to handle requests routed to application services, constructing the service URL using cluster DNS and forwarding headers while skipping hop-by-hop headers.
* Updated the main proxy request handler in `internal/agent/agent.go` to route requests to either the application service (if route context is provided) or the Kubernetes API, improving flexibility for internal and external request handling.

**Route Context Support:**

* Extended the `ProxyRequest` struct in `internal/controlplane/types.go` to include `Namespace`, `ServiceName`, and `ServicePort` fields for specifying application service routing context.
* Modified the proxy request parsing logic in `internal/controlplane/websocket_client.go` to extract route context fields from incoming messages.

**Logging Enhancements:**

* Improved logging in `internal/agent/agent.go` to include route context fields (`namespace`, `service_name`, `service_port`) when available, aiding in debugging and traceability of proxied requests.