### PR TITLE
Potential fix for code scanning alert no. 38: Clear-text logging of sensitive information

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1271,8 +1271,13 @@ func (a *Agent) sendHeartbeat() error {
 		TunnelGrafanaPort:    monInfo.TunnelGrafanaPort,
 	}
 
-	// Debug: Log the heartbeat payload
-	if jsonPayload, err := json.Marshal(heartbeat); err == nil {
+	// Debug: Log the heartbeat payload (with sensitive fields redacted)
+	redactedHeartbeat := *heartbeat
+	// Redact credentials
+	redactedHeartbeat.PrometheusPassword = "[REDACTED]"
+	redactedHeartbeat.LokiPassword = "[REDACTED]"
+	redactedHeartbeat.GrafanaPassword = "[REDACTED]"
+	if jsonPayload, err := json.Marshal(redactedHeartbeat); err == nil {
 		a.logger.WithField("payload", string(jsonPayload)).Debug("Heartbeat payload")
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/38](https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/38)

The best way to fix this problem is to **avoid logging sensitive credential fields at any log level**, especially debug. In this case, before serializing and logging the `heartbeat` object, we should obfuscate or remove the sensitive fields (`PrometheusPassword`, `LokiPassword`, `GrafanaPassword`). The fix should be limited to the debug logging of the heartbeat payload, not to the actual heartbeat transmission. One robust method is to create a shallow copy of the heartbeat object, set the password fields (and possibly usernames) to fixed strings (e.g., `"[REDACTED]"`), then serialize and log that copy.

Implementation steps:
- Before the debug log on line 1276, create a copy of the `heartbeat` struct.
- Set the password (and optionally username) fields of the copy to `"[REDACTED]"`.
- Marshal and log the copy instead of the original.
- No new methods are required; only lines within the shown region are edited.
- No new external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
