### PR TITLE
Potential fix for code scanning alert no. 37: Clear-text logging of sensitive information

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -923,6 +923,8 @@ func (a *Agent) getMonitoringInfo() monitoringInfo {
 		}
 	}
 
+	// WARNING: Never log sensitive fields such as usernames or passwords.
+	// Only include non-sensitive fields like URLs and ports below.
 	a.logger.WithFields(logrus.Fields{
 		"prometheus_url":  info.PrometheusURL,
 		"prometheus_port": info.TunnelPrometheusPort,


### PR DESCRIPTION
Potential fix for [https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/37](https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/37)

The best way to fix this problem is to ensure that sensitive data (usernames and passwords) are *never* included in log fields, neither now nor in the future. Only log non-sensitive fields such as URLs and ports. The code should explicitly construct log fields, ensuring no inclusion of credentials.

Additionally, it is prudent to highlight in comments that sensitive fields must not be added to logs, and to validate that the struct fields used in logging are all non-sensitive.

**Implementation steps:**
- Inspect the log statement: verify only non-sensitive fields are included.
- Add a comment above the log statement warning against logging sensitive fields.
- Optionally, check if logging the entire `info` struct (as a single object) is ever performed; prohibit this.
- No changes are needed to imports or additional dependencies.

No new methods, imports, or dependencies are necessary for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
