### PR TITLE
Potential fix for code scanning alert no. 36: Client-side cross-site scripting

### DIFF
--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -322,8 +322,27 @@
             
             const entry = document.createElement('div');
             entry.className = 'log-entry';
-            entry.innerHTML = `<span class="log-timestamp">[${timestamp}]</span> <span class="log-level-${level}">[${level.toUpperCase()}]</span> ${message}`;
-            
+
+            // Timestamp
+            const timestampSpan = document.createElement('span');
+            timestampSpan.className = 'log-timestamp';
+            timestampSpan.textContent = `[${timestamp}]`;
+
+            // Level
+            const levelSpan = document.createElement('span');
+            levelSpan.className = `log-level-${level}`;
+            levelSpan.textContent = `[${level.toUpperCase()}]`;
+
+            // Message (untrusted data; always must use textContent)
+            const messageSpan = document.createElement('span');
+            messageSpan.textContent = message;
+
+            entry.appendChild(timestampSpan);
+            entry.appendChild(document.createTextNode(' ')); // space
+            entry.appendChild(levelSpan);
+            entry.appendChild(document.createTextNode(' ')); // space
+            entry.appendChild(messageSpan);
+
             logContainer.appendChild(entry);
             logContainer.scrollTop = logContainer.scrollHeight;
 


### PR DESCRIPTION
Potential fix for [https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/36](https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/36)

Generally, the best way to fix this vulnerability is to ensure that any untrusted data is properly escaped or encoded before being inserted into the DOM using HTML contexts. The risk is specifically with the `message` argument passed to `logEvent`, which may contain HTML/JavaScript. The optimal approach is to avoid setting `innerHTML` with unsanitized data. One solution is to use `textContent` for message portions that should be plain text, which will automatically escape HTML. If the template requires some HTML (such as the spans with classes), build the entry using DOM methods (createElement, appendChild, etc.) and only use `textContent` for untrusted values. Alternatively, a simple escape function can be used to encode unsafe characters if necessary.

Specifically, in `logEvent`, we need to ensure that the `message` part of the entry is not directly interpolated into the template string passed to `innerHTML`, but is instead safely inserted as plain text. We will:
- Create the necessary HTML structure for the log entry.
- Set `textContent` for `message` and not interpolate it into an HTML string.
- Update only the `logEvent` function in web/dashboard.html (lines 319-334).
No additional libraries are needed; DOM methods suffice and are standard.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
