### PR TITLE
Potential fix for code scanning alert no. 56: Log entries created from user input

### DIFF
--- a/internal/controlplane/websocket_proxy.go
+++ b/internal/controlplane/websocket_proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -158,7 +159,8 @@ func (m *WebSocketProxyManager) connectToKubernetes(stream *WebSocketStream, met
 		k8sURL = fmt.Sprintf("%s?%s", k8sURL, query)
 	}
 
-	stream.logger.WithField("url", k8sURL).Debug("Connecting to Kubernetes API")
+	safeURL := strings.ReplaceAll(strings.ReplaceAll(k8sURL, "\n", ""), "\r", "")
+	stream.logger.WithField("url", safeURL).Debug("Connecting to Kubernetes API")
 
 	dialer := websocket.Dialer{
 		TLSClientConfig: m.client.tlsConfig,


### PR DESCRIPTION
Potential fix for [https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/56](https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/56)

To fix the problem, all user-provided values that are logged must be sanitized before being included in log entries. Specifically, any input fields that can contain untrusted data (such as `path` or `query`) should have their newlines (`\n`, `\r`) removed or replaced, to prevent an attacker from forging new log entries by injecting line breaks. 

The best solution is to sanitize/cleanse the `k8sURL` value before passing it to the logger. Since `k8sURL` is constructed from both `path` and (optionally) `query`, both components may need sanitizing, but sanitizing the final URL string is simplest and safest. In particular, all `\r` and `\n` characters should be removed from the `k8sURL` string prior to logging.

This requires:
- Importing the `strings` package in `internal/controlplane/websocket_proxy.go` (if not already).
- Modifying the call in `connectToKubernetes` so that the logged `url` field value is a sanitized version of `k8sURL`.
- Optionally, for clarity and security hygiene, the sanitization should occur as close to the logging call as possible.

No new or custom utility functions are needed since we can use `strings.ReplaceAll`. Only the code in `internal/controlplane/websocket_proxy.go` needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
