### PR TITLE
Feat/tcp udp tunneling

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -146,22 +146,22 @@ func shellQuote(value string) string {
 // Note: With Portainer-style tunneling, K8s access happens directly through
 // the tunnel, so we don't need a K8s client in the agent.
 type Agent struct {
-	config                       *types.Config
-	logger                       *logrus.Logger
-	server                       *server.Server
-	controlPlane                 *controlplane.Client
-	tunnelMgr                    *tunnel.Manager
-	monitoringMgr                *components.Manager     // Components manager (monitoring, ingress, metrics)
-	stateManager                 *state.StateManager     // Manages persistent state
-	k8sClient                    *k8s.Client             // Kubernetes client for in-cluster API access
-	gatewayWatcher               *ingress.IngressWatcher // Gateway proxy ingress watcher (for private clusters)
+	config         *types.Config
+	logger         *logrus.Logger
+	server         *server.Server
+	controlPlane   *controlplane.Client
+	tunnelMgr      *tunnel.Manager
+	monitoringMgr  *components.Manager     // Components manager (monitoring, ingress, metrics)
+	stateManager   *state.StateManager     // Manages persistent state
+	k8sClient      *k8s.Client             // Kubernetes client for in-cluster API access
+	gatewayWatcher *ingress.IngressWatcher // Gateway proxy ingress watcher (for private clusters)
 
 	// TCP/UDP tunneling via Gateway API (new architecture)
-	tcpUDPTunnelMgr     *TunnelManager             // TCP/UDP tunnel connection manager
-	gatewayAPIWatcher   *tunnel.GatewayWatcher     // Watches Gateway API resources for tunnel registration
-	tunnelControlClient tunnel.ControlPlaneClient  // Control plane client for tunnel registration
+	tcpUDPTunnelMgr     *TunnelManager            // TCP/UDP tunnel connection manager
+	gatewayAPIWatcher   *tunnel.GatewayWatcher    // Watches Gateway API resources for tunnel registration
+	tunnelControlClient tunnel.ControlPlaneClient // Control plane client for tunnel registration
 
-	metrics                      *Metrics                // Prometheus metrics
+	metrics                      *Metrics // Prometheus metrics
 	ctx                          context.Context
 	cancel                       context.CancelFunc
 	wg                           sync.WaitGroup
@@ -409,15 +409,15 @@ func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 	if config.Tunnels != nil && config.Tunnels.Enabled {
 		// Create tunnel manager config
 		tunnelMgrConfig := &TunnelManagerConfig{
-			TCPBufferSize:         config.Tunnels.TCP.BufferSize,
-			TCPKeepalive:          config.Tunnels.TCP.Keepalive,
-			TCPKeepalivePeriod:    config.Tunnels.TCP.KeepalivePeriod,
-			TCPConnectionTimeout:  config.Tunnels.TCP.ConnectionTimeout,
-			TCPIdleTimeout:        config.Tunnels.TCP.IdleTimeout,
-			TCPMaxConnections:     config.Tunnels.TCP.MaxConnections,
-			UDPBufferSize:         config.Tunnels.UDP.BufferSize,
-			UDPSessionTimeout:     config.Tunnels.UDP.SessionTimeout,
-			UDPMaxSessions:        config.Tunnels.UDP.MaxSessions,
+			TCPBufferSize:        config.Tunnels.TCP.BufferSize,
+			TCPKeepalive:         config.Tunnels.TCP.Keepalive,
+			TCPKeepalivePeriod:   config.Tunnels.TCP.KeepalivePeriod,
+			TCPConnectionTimeout: config.Tunnels.TCP.ConnectionTimeout,
+			TCPIdleTimeout:       config.Tunnels.TCP.IdleTimeout,
+			TCPMaxConnections:    config.Tunnels.TCP.MaxConnections,
+			UDPBufferSize:        config.Tunnels.UDP.BufferSize,
+			UDPSessionTimeout:    config.Tunnels.UDP.SessionTimeout,
+			UDPMaxSessions:       config.Tunnels.UDP.MaxSessions,
 		}
 
 		// Use defaults if not specified
@@ -443,10 +443,10 @@ func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 		}
 
 		logger.WithFields(logrus.Fields{
-			"tcp_enabled":        config.Tunnels.Discovery.TCP.Enabled,
-			"udp_enabled":        config.Tunnels.Discovery.UDP.Enabled,
-			"force_tunnel_mode":  config.Tunnels.Routing.ForceTunnelMode,
-			"dual_mode_enabled":  config.Tunnels.Routing.DualModeEnabled,
+			"tcp_enabled":       config.Tunnels.Discovery.TCP.Enabled,
+			"udp_enabled":       config.Tunnels.Discovery.UDP.Enabled,
+			"force_tunnel_mode": config.Tunnels.Routing.ForceTunnelMode,
+			"dual_mode_enabled": config.Tunnels.Routing.DualModeEnabled,
 		}).Info("TCP/UDP tunneling enabled via Gateway API")
 	} else {
 		logger.Info("TCP/UDP tunneling disabled")

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -40,17 +40,17 @@ type Metrics struct {
 	wsProxyStreamTotal      prometheus.Counter
 
 	// TCP tunnel metrics
-	tcpTunnelActiveConnections prometheus.Gauge
-	tcpTunnelConnectionsTotal  prometheus.Counter
-	tcpTunnelBytesTransferred  *prometheus.CounterVec
-	tcpTunnelConnectionErrors  *prometheus.CounterVec
+	tcpTunnelActiveConnections  prometheus.Gauge
+	tcpTunnelConnectionsTotal   prometheus.Counter
+	tcpTunnelBytesTransferred   *prometheus.CounterVec
+	tcpTunnelConnectionErrors   *prometheus.CounterVec
 	tcpTunnelConnectionDuration prometheus.Histogram
 
 	// UDP tunnel metrics
-	udpTunnelActiveSessions    prometheus.Gauge
-	udpTunnelSessionsTotal     prometheus.Counter
+	udpTunnelActiveSessions     prometheus.Gauge
+	udpTunnelSessionsTotal      prometheus.Counter
 	udpTunnelPacketsTransferred *prometheus.CounterVec
-	udpTunnelPacketErrors      *prometheus.CounterVec
+	udpTunnelPacketErrors       *prometheus.CounterVec
 
 	// Gateway API watcher metrics
 	gatewayWatcherDiscoveredServices prometheus.Gauge

--- a/internal/agent/tcp_tunnel.go
+++ b/internal/agent/tcp_tunnel.go
@@ -262,14 +262,14 @@ func (a *Agent) GetTCPTunnelMetrics(requestID string) (map[string]interface{}, e
 	}
 
 	return map[string]interface{}{
-		"request_id":   tunnel.RequestID,
-		"tunnel_id":    tunnel.TunnelID,
-		"gateway_port": tunnel.GatewayPort,
-		"bytes_sent":   tunnel.BytesSent,
-		"bytes_recv":   tunnel.BytesRecv,
-		"start_time":   tunnel.StartTime,
+		"request_id":    tunnel.RequestID,
+		"tunnel_id":     tunnel.TunnelID,
+		"gateway_port":  tunnel.GatewayPort,
+		"bytes_sent":    tunnel.BytesSent,
+		"bytes_recv":    tunnel.BytesRecv,
+		"start_time":    tunnel.StartTime,
 		"last_activity": tunnel.LastActivity,
-		"duration_ms":  time.Since(tunnel.StartTime).Milliseconds(),
+		"duration_ms":   time.Since(tunnel.StartTime).Milliseconds(),
 	}, nil
 }
 

--- a/internal/agent/tunnel_manager.go
+++ b/internal/agent/tunnel_manager.go
@@ -40,12 +40,12 @@ type TunnelManager struct {
 // TunnelManagerConfig contains configuration for the tunnel manager
 type TunnelManagerConfig struct {
 	// TCP settings
-	TCPBufferSize         int
-	TCPKeepalive          bool
-	TCPKeepalivePeriod    time.Duration
-	TCPConnectionTimeout  time.Duration
-	TCPIdleTimeout        time.Duration
-	TCPMaxConnections     int
+	TCPBufferSize        int
+	TCPKeepalive         bool
+	TCPKeepalivePeriod   time.Duration
+	TCPConnectionTimeout time.Duration
+	TCPIdleTimeout       time.Duration
+	TCPMaxConnections    int
 
 	// UDP settings
 	UDPBufferSize     int
@@ -59,16 +59,16 @@ type TunnelManagerConfig struct {
 // DefaultTunnelManagerConfig returns default configuration
 func DefaultTunnelManagerConfig() *TunnelManagerConfig {
 	return &TunnelManagerConfig{
-		TCPBufferSize:         32 * 1024, // 32KB
-		TCPKeepalive:          true,
-		TCPKeepalivePeriod:    30 * time.Second,
-		TCPConnectionTimeout:  30 * time.Second,
-		TCPIdleTimeout:        5 * time.Minute,
-		TCPMaxConnections:     1000,
-		UDPBufferSize:         65507, // Max UDP packet size
-		UDPSessionTimeout:     5 * time.Minute,
-		UDPMaxSessions:        1000,
-		CleanupInterval:       1 * time.Minute,
+		TCPBufferSize:        32 * 1024, // 32KB
+		TCPKeepalive:         true,
+		TCPKeepalivePeriod:   30 * time.Second,
+		TCPConnectionTimeout: 30 * time.Second,
+		TCPIdleTimeout:       5 * time.Minute,
+		TCPMaxConnections:    1000,
+		UDPBufferSize:        65507, // Max UDP packet size
+		UDPSessionTimeout:    5 * time.Minute,
+		UDPMaxSessions:       1000,
+		CleanupInterval:      1 * time.Minute,
 	}
 }
 
@@ -171,10 +171,10 @@ func (tm *TunnelManager) RemoveTCPConnection(requestID string) {
 		atomic.AddUint64(&tm.tcpBytesTransferred, tunnel.BytesSent+tunnel.BytesRecv)
 
 		tm.logger.WithFields(logrus.Fields{
-			"request_id":  requestID,
-			"bytes_sent":  tunnel.BytesSent,
-			"bytes_recv":  tunnel.BytesRecv,
-			"duration":    time.Since(tunnel.StartTime).String(),
+			"request_id":   requestID,
+			"bytes_sent":   tunnel.BytesSent,
+			"bytes_recv":   tunnel.BytesRecv,
+			"duration":     time.Since(tunnel.StartTime).String(),
 			"active_count": len(tm.tcpConnections),
 		}).Debug("TCP connection removed")
 	}
@@ -226,12 +226,12 @@ func (tm *TunnelManager) RemoveUDPSession(tunnelID string) {
 		atomic.AddUint64(&tm.udpPacketsTransferred, uint64(tunnel.PacketsSent+tunnel.PacketsRecv))
 
 		tm.logger.WithFields(logrus.Fields{
-			"tunnel_id":     tunnelID,
-			"packets_sent":  tunnel.PacketsSent,
-			"packets_recv":  tunnel.PacketsRecv,
-			"sessions":      len(tunnel.Sessions),
-			"duration":      time.Since(tunnel.StartTime).String(),
-			"active_count":  len(tm.udpSessions),
+			"tunnel_id":    tunnelID,
+			"packets_sent": tunnel.PacketsSent,
+			"packets_recv": tunnel.PacketsRecv,
+			"sessions":     len(tunnel.Sessions),
+			"duration":     time.Since(tunnel.StartTime).String(),
+			"active_count": len(tm.udpSessions),
 		}).Debug("UDP session removed")
 	}
 }
@@ -287,8 +287,8 @@ func (tm *TunnelManager) cleanupIdleTCP() {
 	for requestID, tunnel := range tm.tcpConnections {
 		if tunnel.IsIdle(tm.config.TCPIdleTimeout) {
 			tm.logger.WithFields(logrus.Fields{
-				"request_id":  requestID,
-				"idle_time":   now.Sub(tunnel.LastActivity).String(),
+				"request_id": requestID,
+				"idle_time":  now.Sub(tunnel.LastActivity).String(),
 			}).Info("Closing idle TCP connection")
 
 			tunnel.Close()

--- a/internal/agent/tunnel_manager_test.go
+++ b/internal/agent/tunnel_manager_test.go
@@ -26,9 +26,9 @@ func TestNewTunnelManager(t *testing.T) {
 
 	t.Run("with custom config", func(t *testing.T) {
 		config := &TunnelManagerConfig{
-			TCPBufferSize:    64 * 1024,
+			TCPBufferSize:     64 * 1024,
 			TCPMaxConnections: 500,
-			UDPMaxSessions:   500,
+			UDPMaxSessions:    500,
 		}
 		tm := NewTunnelManager(logger, config)
 		require.NotNil(t, tm)
@@ -101,8 +101,8 @@ func TestTunnelManager_TCPOperations(t *testing.T) {
 		// Use a tiny limit for testing
 		config := &TunnelManagerConfig{
 			TCPMaxConnections: 2,
-			UDPMaxSessions:   100,
-			CleanupInterval:  time.Hour, // Don't cleanup during test
+			UDPMaxSessions:    100,
+			CleanupInterval:   time.Hour, // Don't cleanup during test
 		}
 		smallTM := NewTunnelManager(logger, config)
 

--- a/internal/controlplane/types.go
+++ b/internal/controlplane/types.go
@@ -271,8 +271,8 @@ type TCPTunnelClose struct {
 // UDPTunnelData represents a UDP datagram flowing through a tunnel
 // UDP is connectionless, so we use tunnel_id instead of request_id
 type UDPTunnelData struct {
-	TunnelID string `json:"tunnel_id"` // e.g., "udp-abc-123-dns"
-	Data     []byte `json:"data"`      // Raw datagram payload
+	TunnelID  string `json:"tunnel_id"` // e.g., "udp-abc-123-dns"
+	Data      []byte `json:"data"`      // Raw datagram payload
 	Direction string `json:"direction"` // "gateway_to_agent" or "agent_to_gateway"
 
 	// Client session tracking (for routing responses back)

--- a/internal/controlplane/websocket_proxy.go
+++ b/internal/controlplane/websocket_proxy.go
@@ -441,15 +441,15 @@ func isValidK8sAPIPath(path string) bool {
 
 	// Allowed Kubernetes API path prefixes
 	allowedPrefixes := []string{
-		"/api/",           // Core API (pods, services, etc.)
-		"/apis/",          // Extended APIs (deployments, etc.)
-		"/version",        // Cluster version
-		"/healthz",        // Health check
-		"/readyz",         // Readiness check
-		"/livez",          // Liveness check
-		"/openapi/",       // OpenAPI spec
-		"/api",            // Exact match for /api
-		"/apis",           // Exact match for /apis
+		"/api/",     // Core API (pods, services, etc.)
+		"/apis/",    // Extended APIs (deployments, etc.)
+		"/version",  // Cluster version
+		"/healthz",  // Health check
+		"/readyz",   // Readiness check
+		"/livez",    // Liveness check
+		"/openapi/", // OpenAPI spec
+		"/api",      // Exact match for /api
+		"/apis",     // Exact match for /apis
 	}
 
 	for _, prefix := range allowedPrefixes {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -290,14 +290,14 @@ type ClusterMetrics struct {
 
 // Config represents agent configuration
 type Config struct {
-	Agent      AgentConfig          `yaml:"agent" mapstructure:"agent"`
-	PipeOps    PipeOpsConfig        `yaml:"pipeops" mapstructure:"pipeops"`
-	Kubernetes KubernetesConfig     `yaml:"kubernetes" mapstructure:"kubernetes"`
-	Logging    LoggingConfig        `yaml:"logging" mapstructure:"logging"`
-	Tunnel     *TunnelConfig        `yaml:"tunnel,omitempty" mapstructure:"tunnel"`                   // Deprecated: Use Tunnels instead. Will be removed in v2.0.
-	Tunnels    *TCPUDPTunnelConfig  `yaml:"tunnels,omitempty" mapstructure:"tunnels"`                 // TCP/UDP tunneling via Gateway API
-	Gateway    *GatewayConfig       `yaml:"gateway,omitempty" mapstructure:"gateway"`
-	Timeouts   *Timeouts            `yaml:"timeouts" mapstructure:"timeouts"`
+	Agent      AgentConfig         `yaml:"agent" mapstructure:"agent"`
+	PipeOps    PipeOpsConfig       `yaml:"pipeops" mapstructure:"pipeops"`
+	Kubernetes KubernetesConfig    `yaml:"kubernetes" mapstructure:"kubernetes"`
+	Logging    LoggingConfig       `yaml:"logging" mapstructure:"logging"`
+	Tunnel     *TunnelConfig       `yaml:"tunnel,omitempty" mapstructure:"tunnel"`   // Deprecated: Use Tunnels instead. Will be removed in v2.0.
+	Tunnels    *TCPUDPTunnelConfig `yaml:"tunnels,omitempty" mapstructure:"tunnels"` // TCP/UDP tunneling via Gateway API
+	Gateway    *GatewayConfig      `yaml:"gateway,omitempty" mapstructure:"gateway"`
+	Timeouts   *Timeouts           `yaml:"timeouts" mapstructure:"timeouts"`
 }
 
 // AgentConfig represents agent-specific configuration
@@ -631,11 +631,11 @@ type MonitoringCompatibilityConfig struct {
 // TCPUDPTunnelConfig represents TCP/UDP tunneling configuration via Gateway API
 // This enables tunneling to services exposed through Istio Gateway or Gateway API
 type TCPUDPTunnelConfig struct {
-	Enabled   bool                      `yaml:"enabled" mapstructure:"enabled"`
-	Routing   TunnelRoutingConfig       `yaml:"routing" mapstructure:"routing"`
-	Discovery TunnelDiscoveryConfig     `yaml:"discovery" mapstructure:"discovery"`
-	TCP       TCPTunnelProtocolConfig   `yaml:"tcp" mapstructure:"tcp"`
-	UDP       UDPTunnelProtocolConfig   `yaml:"udp" mapstructure:"udp"`
+	Enabled   bool                    `yaml:"enabled" mapstructure:"enabled"`
+	Routing   TunnelRoutingConfig     `yaml:"routing" mapstructure:"routing"`
+	Discovery TunnelDiscoveryConfig   `yaml:"discovery" mapstructure:"discovery"`
+	TCP       TCPTunnelProtocolConfig `yaml:"tcp" mapstructure:"tcp"`
+	UDP       UDPTunnelProtocolConfig `yaml:"udp" mapstructure:"udp"`
 }
 
 // TunnelRoutingConfig controls routing mode behavior


### PR DESCRIPTION
This pull request adds multiple layers of validation and sanitization to the WebSocket proxy logic to enhance security, particularly against SSRF and injection attacks. The key changes include strict validation of API paths, sanitization of URL components, and additional checks to prevent host manipulation.

**Security enhancements:**

* Added a check in `HandleWebSocketProxyStart` to validate that the requested path is a legitimate Kubernetes API endpoint, rejecting any request with an invalid path to prevent SSRF attacks.
* Introduced the `isValidK8sAPIPath` function to rigorously verify that only allowed Kubernetes API path prefixes are accepted, and to block suspicious characters or path traversal attempts.

**Input sanitization and URL construction:**

* Implemented `sanitizeURLPath` and `sanitizeQueryString` functions to clean potentially dangerous characters from paths and query strings before constructing the Kubernetes API URL.
* Updated the URL construction in `connectToKubernetes` to use the sanitized path and query, and added a final validation step to ensure the constructed URL is well-formed and the host has not been manipulated.