### PR TITLE
feat: add yamux stream multiplexing for L4 tunneling

### DIFF
--- a/docs/advanced/tcp-udp-tunneling.md
+++ b/docs/advanced/tcp-udp-tunneling.md
@@ -43,6 +43,22 @@ PipeOps TCP/UDP tunneling allows you to expose TCP and UDP services from your Ku
 | **tunnel** | WebSocket through PipeOps gateway | Private clusters, NAT, firewalls |
 | **dual** | Both direct + tunnel endpoints | Redundancy, client choice |
 
+### Protocol Options
+
+The agent supports two tunnel protocols:
+
+| Protocol | Description | Performance |
+|----------|-------------|-------------|
+| **JSON** | Base64-encoded data over WebSocket | Compatible, ~33% overhead |
+| **Yamux** | Binary stream multiplexing | Optimal, zero encoding overhead |
+
+The agent automatically negotiates yamux when the gateway supports it. Yamux provides:
+
+- **Zero base64 overhead**: Raw bytes instead of base64-encoded JSON
+- **Per-stream backpressure**: Flow control prevents memory exhaustion  
+- **Lower latency**: No JSON parsing per message
+- **True multiplexing**: Multiple concurrent tunnels over single connection
+
 ## Prerequisites
 
 1. **Gateway API CRDs** - Including experimental TCPRoute/UDPRoute

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/hashicorp/yamux v0.1.2
 	github.com/jpillora/chisel v1.10.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvH
 github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/internal/tunnel/stream_header.go
+++ b/internal/tunnel/stream_header.go
@@ -1,0 +1,103 @@
+package tunnel
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+const (
+	// TunnelStreamHeaderVersion is the current version of the tunnel stream header protocol
+	TunnelStreamHeaderVersion uint8 = 1
+
+	// TunnelProtocolTCP indicates a TCP tunnel stream
+	TunnelProtocolTCP uint8 = 1
+
+	// TunnelProtocolUDP indicates a UDP tunnel stream
+	TunnelProtocolUDP uint8 = 2
+)
+
+// TunnelStreamHeader is sent by the gateway at the start of each yamux stream
+// It contains routing information to identify the target service
+type TunnelStreamHeader struct {
+	Version          uint8
+	Protocol         uint8
+	ServicePort      uint16
+	ServiceName      string
+	ServiceNamespace string
+	TunnelID         string
+}
+
+// ReadFrom reads the header from a stream
+func (h *TunnelStreamHeader) ReadFrom(r io.Reader) error {
+	if err := binary.Read(r, binary.BigEndian, &h.Version); err != nil {
+		return err
+	}
+	if err := binary.Read(r, binary.BigEndian, &h.Protocol); err != nil {
+		return err
+	}
+	if err := binary.Read(r, binary.BigEndian, &h.ServicePort); err != nil {
+		return err
+	}
+
+	var err error
+	h.ServiceName, err = readString(r)
+	if err != nil {
+		return err
+	}
+	h.ServiceNamespace, err = readString(r)
+	if err != nil {
+		return err
+	}
+	h.TunnelID, err = readString(r)
+	return err
+}
+
+// WriteTo writes the header to a stream
+func (h *TunnelStreamHeader) WriteTo(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, h.Version); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, h.Protocol); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, h.ServicePort); err != nil {
+		return err
+	}
+
+	if err := writeString(w, h.ServiceName); err != nil {
+		return err
+	}
+	if err := writeString(w, h.ServiceNamespace); err != nil {
+		return err
+	}
+	return writeString(w, h.TunnelID)
+}
+
+// readString reads a length-prefixed string from the reader
+func readString(r io.Reader) (string, error) {
+	var length uint16
+	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+		return "", err
+	}
+	if length == 0 {
+		return "", nil
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// writeString writes a length-prefixed string to the writer
+func writeString(w io.Writer, s string) error {
+	length := uint16(len(s))
+	if err := binary.Write(w, binary.BigEndian, length); err != nil {
+		return err
+	}
+	if length > 0 {
+		_, err := w.Write([]byte(s))
+		return err
+	}
+	return nil
+}

--- a/internal/tunnel/stream_header_test.go
+++ b/internal/tunnel/stream_header_test.go
@@ -1,0 +1,148 @@
+package tunnel
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTunnelStreamHeader_ReadWrite(t *testing.T) {
+	testCases := []struct {
+		name   string
+		header TunnelStreamHeader
+	}{
+		{
+			name: "TCP tunnel",
+			header: TunnelStreamHeader{
+				Version:          TunnelStreamHeaderVersion,
+				Protocol:         TunnelProtocolTCP,
+				ServicePort:      5432,
+				ServiceName:      "postgres",
+				ServiceNamespace: "databases",
+				TunnelID:         "tunnel-abc123",
+			},
+		},
+		{
+			name: "UDP tunnel",
+			header: TunnelStreamHeader{
+				Version:          TunnelStreamHeaderVersion,
+				Protocol:         TunnelProtocolUDP,
+				ServicePort:      53,
+				ServiceName:      "coredns",
+				ServiceNamespace: "kube-system",
+				TunnelID:         "tunnel-dns-001",
+			},
+		},
+		{
+			name: "empty strings",
+			header: TunnelStreamHeader{
+				Version:          1,
+				Protocol:         TunnelProtocolTCP,
+				ServicePort:      80,
+				ServiceName:      "",
+				ServiceNamespace: "",
+				TunnelID:         "",
+			},
+		},
+		{
+			name: "unicode service name",
+			header: TunnelStreamHeader{
+				Version:          1,
+				Protocol:         TunnelProtocolTCP,
+				ServicePort:      8080,
+				ServiceName:      "service-测试",
+				ServiceNamespace: "namespace-ñ",
+				TunnelID:         "tunnel-émoji-🚀",
+			},
+		},
+		{
+			name: "max port",
+			header: TunnelStreamHeader{
+				Version:          1,
+				Protocol:         TunnelProtocolTCP,
+				ServicePort:      65535,
+				ServiceName:      "high-port-svc",
+				ServiceNamespace: "default",
+				TunnelID:         "tunnel-max-port",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Write to buffer
+			var buf bytes.Buffer
+			err := tc.header.WriteTo(&buf)
+			require.NoError(t, err)
+
+			// Read back
+			var decoded TunnelStreamHeader
+			err = decoded.ReadFrom(&buf)
+			require.NoError(t, err)
+
+			// Compare
+			assert.Equal(t, tc.header.Version, decoded.Version)
+			assert.Equal(t, tc.header.Protocol, decoded.Protocol)
+			assert.Equal(t, tc.header.ServicePort, decoded.ServicePort)
+			assert.Equal(t, tc.header.ServiceName, decoded.ServiceName)
+			assert.Equal(t, tc.header.ServiceNamespace, decoded.ServiceNamespace)
+			assert.Equal(t, tc.header.TunnelID, decoded.TunnelID)
+		})
+	}
+}
+
+func TestTunnelStreamHeader_ReadFromEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	var header TunnelStreamHeader
+	err := header.ReadFrom(&buf)
+	assert.Error(t, err) // Should fail on empty buffer
+}
+
+func TestTunnelStreamHeader_ReadFromTruncated(t *testing.T) {
+	// Write a header
+	original := TunnelStreamHeader{
+		Version:          1,
+		Protocol:         TunnelProtocolTCP,
+		ServicePort:      5432,
+		ServiceName:      "postgres",
+		ServiceNamespace: "databases",
+		TunnelID:         "tunnel-123",
+	}
+
+	var buf bytes.Buffer
+	err := original.WriteTo(&buf)
+	require.NoError(t, err)
+
+	// Truncate the buffer
+	truncated := buf.Bytes()[:10]
+
+	var header TunnelStreamHeader
+	err = header.ReadFrom(bytes.NewReader(truncated))
+	assert.Error(t, err) // Should fail on truncated data
+}
+
+func TestProtocolConstants(t *testing.T) {
+	assert.Equal(t, TunnelProtocolTCP, uint8(1))
+	assert.Equal(t, TunnelProtocolUDP, uint8(2))
+	assert.Equal(t, TunnelStreamHeaderVersion, uint8(1))
+}
+
+func BenchmarkTunnelStreamHeader_WriteRead(b *testing.B) {
+	header := TunnelStreamHeader{
+		Version:          1,
+		Protocol:         TunnelProtocolTCP,
+		ServicePort:      5432,
+		ServiceName:      "postgres",
+		ServiceNamespace: "databases",
+		TunnelID:         "tunnel-abc123",
+	}
+
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		_ = header.WriteTo(&buf)
+		var decoded TunnelStreamHeader
+		_ = decoded.ReadFrom(&buf)
+	}
+}

--- a/internal/tunnel/wsconn.go
+++ b/internal/tunnel/wsconn.go
@@ -1,0 +1,140 @@
+package tunnel
+
+import (
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// WSConn wraps a WebSocket connection to implement net.Conn
+// This adapter is required for yamux which expects a net.Conn interface
+type WSConn struct {
+	ws       *websocket.Conn
+	reader   io.Reader
+	readerMu sync.Mutex
+	writeMu  sync.Mutex
+	closed   bool
+	closedMu sync.RWMutex
+}
+
+// NewWSConn creates a new WSConn wrapping a WebSocket connection
+func NewWSConn(ws *websocket.Conn) *WSConn {
+	return &WSConn{ws: ws}
+}
+
+// Read implements io.Reader for the WebSocket connection
+// It reads binary messages from the WebSocket and returns them as a byte stream
+func (c *WSConn) Read(b []byte) (int, error) {
+	c.closedMu.RLock()
+	if c.closed {
+		c.closedMu.RUnlock()
+		return 0, io.EOF
+	}
+	c.closedMu.RUnlock()
+
+	c.readerMu.Lock()
+	defer c.readerMu.Unlock()
+
+	for {
+		if c.reader != nil {
+			n, err := c.reader.Read(b)
+			if err == io.EOF {
+				c.reader = nil
+				if n > 0 {
+					return n, nil
+				}
+				continue
+			}
+			return n, err
+		}
+
+		messageType, reader, err := c.ws.NextReader()
+		if err != nil {
+			return 0, err
+		}
+
+		// Only handle binary messages for yamux
+		if messageType != websocket.BinaryMessage {
+			io.Copy(io.Discard, reader)
+			continue
+		}
+
+		c.reader = reader
+	}
+}
+
+// Write implements io.Writer for the WebSocket connection
+// It sends data as binary WebSocket messages
+func (c *WSConn) Write(b []byte) (int, error) {
+	c.closedMu.RLock()
+	if c.closed {
+		c.closedMu.RUnlock()
+		return 0, io.ErrClosedPipe
+	}
+	c.closedMu.RUnlock()
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	err := c.ws.WriteMessage(websocket.BinaryMessage, b)
+	if err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// Close closes the WebSocket connection
+func (c *WSConn) Close() error {
+	c.closedMu.Lock()
+	if c.closed {
+		c.closedMu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.closedMu.Unlock()
+
+	c.writeMu.Lock()
+	c.ws.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	c.writeMu.Unlock()
+
+	return c.ws.Close()
+}
+
+// LocalAddr returns the local network address
+func (c *WSConn) LocalAddr() net.Addr {
+	return c.ws.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address
+func (c *WSConn) RemoteAddr() net.Addr {
+	return c.ws.RemoteAddr()
+}
+
+// SetDeadline sets both read and write deadlines
+func (c *WSConn) SetDeadline(t time.Time) error {
+	if err := c.ws.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return c.ws.SetWriteDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline
+func (c *WSConn) SetReadDeadline(t time.Time) error {
+	return c.ws.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline
+func (c *WSConn) SetWriteDeadline(t time.Time) error {
+	return c.ws.SetWriteDeadline(t)
+}
+
+// IsClosed returns whether the connection is closed
+func (c *WSConn) IsClosed() bool {
+	c.closedMu.RLock()
+	defer c.closedMu.RUnlock()
+	return c.closed
+}

--- a/internal/tunnel/wsconn_test.go
+++ b/internal/tunnel/wsconn_test.go
@@ -1,0 +1,215 @@
+package tunnel
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upgrader for tests
+var testUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+func TestWSConn_ReadWrite(t *testing.T) {
+	// Create a WebSocket test server
+	var serverConn *websocket.Conn
+	var serverWG sync.WaitGroup
+	serverWG.Add(1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		serverConn, err = testUpgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		serverWG.Done()
+	}))
+	defer server.Close()
+
+	// Connect client
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	serverWG.Wait()
+	defer serverConn.Close()
+
+	// Wrap both in WSConn
+	clientWSConn := NewWSConn(clientConn)
+	serverWSConn := NewWSConn(serverConn)
+
+	// Test write from client, read from server
+	testData := []byte("hello yamux!")
+
+	// Write in goroutine
+	go func() {
+		n, err := clientWSConn.Write(testData)
+		assert.NoError(t, err)
+		assert.Equal(t, len(testData), n)
+	}()
+
+	// Read on server
+	buf := make([]byte, 1024)
+	n, err := serverWSConn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, testData, buf[:n])
+}
+
+func TestWSConn_Close(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := testUpgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		// Just accept and close
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	wsConn := NewWSConn(clientConn)
+	assert.False(t, wsConn.IsClosed())
+
+	err = wsConn.Close()
+	assert.NoError(t, err)
+	assert.True(t, wsConn.IsClosed())
+
+	// Double close should be safe
+	err = wsConn.Close()
+	assert.NoError(t, err)
+}
+
+func TestWSConn_ReadAfterClose(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := testUpgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	wsConn := NewWSConn(clientConn)
+	wsConn.Close()
+
+	buf := make([]byte, 1024)
+	_, err = wsConn.Read(buf)
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestWSConn_WriteAfterClose(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := testUpgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	wsConn := NewWSConn(clientConn)
+	wsConn.Close()
+
+	_, err = wsConn.Write([]byte("test"))
+	assert.Equal(t, io.ErrClosedPipe, err)
+}
+
+func TestWSConn_NetConnInterface(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := testUpgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	wsConn := NewWSConn(clientConn)
+
+	// Verify it implements net.Conn
+	var _ net.Conn = wsConn
+
+	// Test address methods
+	assert.NotNil(t, wsConn.LocalAddr())
+	assert.NotNil(t, wsConn.RemoteAddr())
+
+	// Test deadline methods (should not error)
+	err = wsConn.SetDeadline(time.Now().Add(time.Second))
+	assert.NoError(t, err)
+
+	err = wsConn.SetReadDeadline(time.Now().Add(time.Second))
+	assert.NoError(t, err)
+
+	err = wsConn.SetWriteDeadline(time.Now().Add(time.Second))
+	assert.NoError(t, err)
+}
+
+func TestWSConn_LargeMessage(t *testing.T) {
+	var serverConn *websocket.Conn
+	var serverWG sync.WaitGroup
+	serverWG.Add(1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		serverConn, err = testUpgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		serverWG.Done()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	serverWG.Wait()
+	defer serverConn.Close()
+
+	clientWSConn := NewWSConn(clientConn)
+	serverWSConn := NewWSConn(serverConn)
+
+	// Send 64KB of data
+	largeData := bytes.Repeat([]byte("X"), 64*1024)
+
+	go func() {
+		n, err := clientWSConn.Write(largeData)
+		assert.NoError(t, err)
+		assert.Equal(t, len(largeData), n)
+	}()
+
+	received := make([]byte, 0, len(largeData))
+	buf := make([]byte, 4096)
+	for len(received) < len(largeData) {
+		n, err := serverWSConn.Read(buf)
+		if err != nil {
+			break
+		}
+		received = append(received, buf[:n]...)
+	}
+
+	assert.Equal(t, largeData, received)
+}

--- a/internal/tunnel/yamux_client.go
+++ b/internal/tunnel/yamux_client.go
@@ -1,0 +1,288 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/hashicorp/yamux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	yamuxStreamsAccepted = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pipeops_agent_yamux_streams_accepted_total",
+			Help: "Total yamux streams accepted from gateway",
+		},
+	)
+
+	yamuxStreamDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "pipeops_agent_yamux_stream_duration_seconds",
+			Help:    "Duration of yamux tunnel streams",
+			Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+		},
+	)
+
+	yamuxBytesTransferred = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipeops_agent_yamux_bytes_total",
+			Help: "Bytes transferred through yamux",
+		},
+		[]string{"direction"}, // "in" or "out"
+	)
+
+	yamuxActiveStreams = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "pipeops_agent_yamux_active_streams",
+			Help: "Number of currently active yamux streams",
+		},
+	)
+
+	yamuxStreamErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipeops_agent_yamux_stream_errors_total",
+			Help: "Total errors in yamux stream handling",
+		},
+		[]string{"type"}, // "dial_error", "header_error", "copy_error"
+	)
+)
+
+// YamuxConfig holds configuration for the yamux tunnel client
+type YamuxConfig struct {
+	MaxStreamWindowSize uint32
+	KeepAliveInterval   time.Duration
+	ConnectionTimeout   time.Duration
+	AcceptBacklog       int
+}
+
+// DefaultYamuxConfig returns default yamux configuration
+func DefaultYamuxConfig() YamuxConfig {
+	return YamuxConfig{
+		MaxStreamWindowSize: 256 * 1024, // 256KB
+		KeepAliveInterval:   30 * time.Second,
+		ConnectionTimeout:   10 * time.Second,
+		AcceptBacklog:       256,
+	}
+}
+
+// YamuxTunnelClient manages yamux multiplexed tunnel streams
+type YamuxTunnelClient struct {
+	session     *yamux.Session
+	wsConn      *WSConn
+	clusterUUID string
+	config      YamuxConfig
+	logger      *logrus.Logger
+
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	activeStreams int64
+}
+
+// NewYamuxTunnelClient creates a new yamux tunnel client
+func NewYamuxTunnelClient(clusterUUID string, ws *websocket.Conn, config YamuxConfig, logger *logrus.Logger) (*YamuxTunnelClient, error) {
+	wsConn := NewWSConn(ws)
+
+	// Configure yamux - agent is CLIENT (accepts streams from gateway SERVER)
+	yamuxCfg := yamux.DefaultConfig()
+	yamuxCfg.AcceptBacklog = config.AcceptBacklog
+	yamuxCfg.EnableKeepAlive = true
+	yamuxCfg.KeepAliveInterval = config.KeepAliveInterval
+	yamuxCfg.ConnectionWriteTimeout = config.ConnectionTimeout
+	yamuxCfg.MaxStreamWindowSize = config.MaxStreamWindowSize
+
+	// Agent is CLIENT - accepts streams opened by gateway
+	session, err := yamux.Client(wsConn, yamuxCfg)
+	if err != nil {
+		wsConn.Close()
+		return nil, fmt.Errorf("failed to create yamux client: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client := &YamuxTunnelClient{
+		session:     session,
+		wsConn:      wsConn,
+		clusterUUID: clusterUUID,
+		config:      config,
+		logger:      logger,
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	return client, nil
+}
+
+// Run starts accepting streams from the gateway
+func (c *YamuxTunnelClient) Run() error {
+	c.logger.WithField("cluster_uuid", c.clusterUUID).Info("[YAMUX] Starting tunnel client")
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return nil
+		default:
+		}
+
+		// Accept stream opened by gateway
+		stream, err := c.session.AcceptStream()
+		if err != nil {
+			if c.ctx.Err() != nil {
+				return nil // Context cancelled, clean shutdown
+			}
+			if err == yamux.ErrSessionShutdown {
+				c.logger.Info("[YAMUX] Session shutdown, stopping client")
+				return nil
+			}
+			return fmt.Errorf("accept stream error: %w", err)
+		}
+
+		yamuxStreamsAccepted.Inc()
+		atomic.AddInt64(&c.activeStreams, 1)
+		yamuxActiveStreams.Set(float64(atomic.LoadInt64(&c.activeStreams)))
+
+		c.wg.Add(1)
+		go func(s *yamux.Stream) {
+			defer c.wg.Done()
+			defer func() {
+				atomic.AddInt64(&c.activeStreams, -1)
+				yamuxActiveStreams.Set(float64(atomic.LoadInt64(&c.activeStreams)))
+			}()
+			c.handleStream(s)
+		}(stream)
+	}
+}
+
+// handleStream processes a single tunnel stream
+func (c *YamuxTunnelClient) handleStream(stream *yamux.Stream) {
+	startTime := time.Now()
+	defer func() {
+		stream.Close()
+		yamuxStreamDuration.Observe(time.Since(startTime).Seconds())
+	}()
+
+	// Read tunnel header
+	var header TunnelStreamHeader
+	if err := header.ReadFrom(stream); err != nil {
+		c.logger.WithError(err).Error("[YAMUX] Failed to read tunnel header")
+		yamuxStreamErrors.WithLabelValues("header_error").Inc()
+		return
+	}
+
+	logger := c.logger.WithFields(logrus.Fields{
+		"service":   header.ServiceName,
+		"namespace": header.ServiceNamespace,
+		"port":      header.ServicePort,
+		"tunnel_id": header.TunnelID,
+		"protocol":  protocolName(header.Protocol),
+	})
+
+	logger.Debug("[YAMUX] Received tunnel stream")
+
+	// Dial target service
+	target := fmt.Sprintf("%s.%s.svc.cluster.local:%d",
+		header.ServiceName, header.ServiceNamespace, header.ServicePort)
+
+	var targetConn net.Conn
+	var err error
+
+	if header.Protocol == TunnelProtocolUDP {
+		targetConn, err = net.DialTimeout("udp", target, c.config.ConnectionTimeout)
+	} else {
+		targetConn, err = net.DialTimeout("tcp", target, c.config.ConnectionTimeout)
+	}
+
+	if err != nil {
+		logger.WithError(err).Errorf("[YAMUX] Failed to dial target %s", target)
+		yamuxStreamErrors.WithLabelValues("dial_error").Inc()
+		return
+	}
+	defer targetConn.Close()
+
+	logger.Debugf("[YAMUX] Connected to target %s", target)
+
+	// Bidirectional copy with metrics
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Stream -> Target (data from gateway client to target service)
+	go func() {
+		defer wg.Done()
+		n, err := io.Copy(targetConn, stream)
+		if err != nil && err != io.EOF {
+			logger.WithError(err).Debug("[YAMUX] Error copying stream->target")
+		}
+		yamuxBytesTransferred.WithLabelValues("in").Add(float64(n))
+		// Signal EOF to target
+		if tc, ok := targetConn.(*net.TCPConn); ok {
+			tc.CloseWrite()
+		}
+	}()
+
+	// Target -> Stream (data from target service back to gateway client)
+	go func() {
+		defer wg.Done()
+		n, err := io.Copy(stream, targetConn)
+		if err != nil && err != io.EOF {
+			logger.WithError(err).Debug("[YAMUX] Error copying target->stream")
+		}
+		yamuxBytesTransferred.WithLabelValues("out").Add(float64(n))
+		stream.Close()
+	}()
+
+	wg.Wait()
+	logger.Debug("[YAMUX] Tunnel stream closed")
+}
+
+// Close shuts down the yamux session
+func (c *YamuxTunnelClient) Close() error {
+	c.logger.Info("[YAMUX] Shutting down tunnel client")
+	c.cancel()
+
+	// Wait for active streams to finish (with timeout)
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.logger.Info("[YAMUX] All streams closed gracefully")
+	case <-time.After(30 * time.Second):
+		c.logger.Warn("[YAMUX] Timeout waiting for streams to close")
+	}
+
+	return c.session.Close()
+}
+
+// IsReady returns true if the yamux session is active
+func (c *YamuxTunnelClient) IsReady() bool {
+	return !c.session.IsClosed() && !c.wsConn.IsClosed()
+}
+
+// ActiveStreamCount returns the number of active streams
+func (c *YamuxTunnelClient) ActiveStreamCount() int64 {
+	return atomic.LoadInt64(&c.activeStreams)
+}
+
+// protocolName returns a human-readable protocol name
+func protocolName(p uint8) string {
+	switch p {
+	case TunnelProtocolTCP:
+		return "TCP"
+	case TunnelProtocolUDP:
+		return "UDP"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
- Add github.com/hashicorp/yamux dependency for stream multiplexing
- Add WSConn adapter (internal/tunnel/wsconn.go) to wrap WebSocket as net.Conn
- Add TunnelStreamHeader (internal/tunnel/stream_header.go) for binary protocol
- Add YamuxTunnelClient (internal/tunnel/yamux_client.go) for accepting streams
- Add gateway_hello handler in websocket_client for protocol negotiation
- Add supports_yamux capability advertisement to gateway connection
- Add Prometheus metrics: yamux_streams_accepted, stream_duration, bytes_total, active_streams, stream_errors
- Add unit tests for WSConn and TunnelStreamHeader
- Update TCP/UDP tunneling docs with yamux protocol information

Benefits of yamux over JSON protocol:
- Zero base64 encoding overhead (33% bandwidth savings)
- Per-stream backpressure for memory safety
- Lower latency without JSON parsing per message
- True TCP-like stream multiplexing over single WebSocket