### PR TITLE
fix: rename ReadFrom/WriteTo to Decode/Encode to avoid io interface c…

### DIFF
--- a/internal/tunnel/stream_header.go
+++ b/internal/tunnel/stream_header.go
@@ -27,8 +27,8 @@ type TunnelStreamHeader struct {
 	TunnelID         string
 }
 
-// ReadFrom reads the header from a stream
-func (h *TunnelStreamHeader) ReadFrom(r io.Reader) error {
+// Decode reads the header from a stream
+func (h *TunnelStreamHeader) Decode(r io.Reader) error {
 	if err := binary.Read(r, binary.BigEndian, &h.Version); err != nil {
 		return err
 	}
@@ -52,8 +52,8 @@ func (h *TunnelStreamHeader) ReadFrom(r io.Reader) error {
 	return err
 }
 
-// WriteTo writes the header to a stream
-func (h *TunnelStreamHeader) WriteTo(w io.Writer) error {
+// Encode writes the header to a stream
+func (h *TunnelStreamHeader) Encode(w io.Writer) error {
 	if err := binary.Write(w, binary.BigEndian, h.Version); err != nil {
 		return err
 	}

--- a/internal/tunnel/stream_header_test.go
+++ b/internal/tunnel/stream_header_test.go
@@ -74,12 +74,12 @@ func TestTunnelStreamHeader_ReadWrite(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Write to buffer
 			var buf bytes.Buffer
-			err := tc.header.WriteTo(&buf)
+			err := tc.header.Encode(&buf)
 			require.NoError(t, err)
 
 			// Read back
 			var decoded TunnelStreamHeader
-			err = decoded.ReadFrom(&buf)
+			err = decoded.Decode(&buf)
 			require.NoError(t, err)
 
 			// Compare
@@ -93,14 +93,14 @@ func TestTunnelStreamHeader_ReadWrite(t *testing.T) {
 	}
 }
 
-func TestTunnelStreamHeader_ReadFromEmpty(t *testing.T) {
+func TestTunnelStreamHeader_DecodeEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	var header TunnelStreamHeader
-	err := header.ReadFrom(&buf)
+	err := header.Decode(&buf)
 	assert.Error(t, err) // Should fail on empty buffer
 }
 
-func TestTunnelStreamHeader_ReadFromTruncated(t *testing.T) {
+func TestTunnelStreamHeader_DecodeTruncated(t *testing.T) {
 	// Write a header
 	original := TunnelStreamHeader{
 		Version:          1,
@@ -112,14 +112,14 @@ func TestTunnelStreamHeader_ReadFromTruncated(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := original.WriteTo(&buf)
+	err := original.Encode(&buf)
 	require.NoError(t, err)
 
 	// Truncate the buffer
 	truncated := buf.Bytes()[:10]
 
 	var header TunnelStreamHeader
-	err = header.ReadFrom(bytes.NewReader(truncated))
+	err = header.Decode(bytes.NewReader(truncated))
 	assert.Error(t, err) // Should fail on truncated data
 }
 
@@ -129,7 +129,7 @@ func TestProtocolConstants(t *testing.T) {
 	assert.Equal(t, TunnelStreamHeaderVersion, uint8(1))
 }
 
-func BenchmarkTunnelStreamHeader_WriteRead(b *testing.B) {
+func BenchmarkTunnelStreamHeader_EncodeDecode(b *testing.B) {
 	header := TunnelStreamHeader{
 		Version:          1,
 		Protocol:         TunnelProtocolTCP,
@@ -141,8 +141,8 @@ func BenchmarkTunnelStreamHeader_WriteRead(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		var buf bytes.Buffer
-		_ = header.WriteTo(&buf)
+		_ = header.Encode(&buf)
 		var decoded TunnelStreamHeader
-		_ = decoded.ReadFrom(&buf)
+		_ = decoded.Decode(&buf)
 	}
 }

--- a/internal/tunnel/yamux_client.go
+++ b/internal/tunnel/yamux_client.go
@@ -172,7 +172,7 @@ func (c *YamuxTunnelClient) handleStream(stream *yamux.Stream) {
 
 	// Read tunnel header
 	var header TunnelStreamHeader
-	if err := header.ReadFrom(stream); err != nil {
+	if err := header.Decode(stream); err != nil {
 		c.logger.WithError(err).Error("[YAMUX] Failed to read tunnel header")
 		yamuxStreamErrors.WithLabelValues("header_error").Inc()
 		return


### PR DESCRIPTION
…onflict

The method names ReadFrom and WriteTo conflict with the standard library io.ReaderFrom and io.WriterTo interfaces which require different signatures. Renamed to Decode/Encode to avoid the linting error.