### PR TITLE
fix: increase default WebSocket handshake timeout to 30s

### DIFF
--- a/pkg/types/timeouts.go
+++ b/pkg/types/timeouts.go
@@ -42,7 +42,7 @@ type Timeouts struct {
 func DefaultTimeouts() *Timeouts {
 	return &Timeouts{
 		// WebSocket timeouts
-		WebSocketHandshake:    10 * time.Second,
+		WebSocketHandshake:    30 * time.Second, // Increased from 10s to handle slow connections
 		WebSocketPing:         30 * time.Second,
 		WebSocketRead:         60 * time.Second,       // 2x ping interval
 		WebSocketReconnect:    500 * time.Millisecond, // Fast initial reconnect
@@ -55,7 +55,7 @@ func DefaultTimeouts() *Timeouts {
 
 		// HTTP proxy timeouts
 		ProxyRequest: 30 * time.Second,
-		ProxyDial:    10 * time.Second,
+		ProxyDial:    30 * time.Second, // Increased from 10s
 		ProxyIdle:    90 * time.Second,
 
 		// Registration and heartbeat


### PR DESCRIPTION
This pull request increases timeout values in the `DefaultTimeouts` configuration to improve reliability for slower connections. The main changes are:

**WebSocket timeouts:**
* Increased `WebSocketHandshake` timeout from 10 seconds to 30 seconds to better handle slow connections.

**HTTP proxy timeouts:**
* Increased `ProxyDial` timeout from 10 seconds to 30 seconds for improved connection reliability.