### PR TITLE
feat: replace nginx ingress with traefik and implement graceful migration

### DIFF
--- a/internal/components/orchestrator.go
+++ b/internal/components/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -20,7 +21,7 @@ type InstallStep struct {
 }
 
 // executeInstallationPlan runs the installation steps with resource-aware gating
-func (m *Manager) executeInstallationPlan(profile ResourceProfile, steps []InstallStep) error {
+func (m *Manager) executeInstallationPlan(profile types.ResourceProfile, steps []InstallStep) error {
 	for i, step := range steps {
 		m.logger.WithFields(logrus.Fields{
 			"component": step.Name,
@@ -45,12 +46,12 @@ func (m *Manager) executeInstallationPlan(profile ResourceProfile, steps []Insta
 }
 
 // waitForComponentReady waits for the resources associated with a release to become ready
-func (m *Manager) waitForComponentReady(namespace, releaseName string, profile ResourceProfile) {
+func (m *Manager) waitForComponentReady(namespace, releaseName string, profile types.ResourceProfile) {
 	// Skip if no release name provided (e.g. simple manifests or CRDs)
 	if releaseName == "" {
 		// Just a static sleep for non-Helm components based on profile
 		sleepTime := 10 * time.Second
-		if profile == ProfileLow {
+		if profile == types.ProfileLow {
 			sleepTime = 30 * time.Second
 		}
 		m.logger.WithField("duration", sleepTime).Info("Waiting for static stabilization...")
@@ -59,7 +60,7 @@ func (m *Manager) waitForComponentReady(namespace, releaseName string, profile R
 	}
 
 	timeout := 5 * time.Minute
-	if profile == ProfileLow {
+	if profile == types.ProfileLow {
 		timeout = 10 * time.Minute // Give low resource nodes more time
 	}
 
@@ -89,7 +90,7 @@ func (m *Manager) waitForComponentReady(namespace, releaseName string, profile R
 				
 				// Cool-down period after ready state to allow CPU to drop
 				coolDown := 5 * time.Second
-				if profile == ProfileLow {
+				if profile == types.ProfileLow {
 					coolDown = 30 * time.Second // Significant cool-down for low resource nodes
 				}
 				m.logger.WithField("duration", coolDown).Info("Cooling down before next step...")

--- a/internal/components/resources.go
+++ b/internal/components/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -11,21 +12,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// ResourceProfile represents the capability level of the cluster
-type ResourceProfile string
-
-const (
-	ProfileLow    ResourceProfile = "low"    // < 4GB RAM or < 2 CPUs (Minimal install, serial)
-	ProfileMedium ResourceProfile = "medium" // 4GB-8GB RAM (Standard install)
-	ProfileHigh   ResourceProfile = "high"   // > 8GB RAM (Performance install)
-)
-
 // ClusterCapacity holds aggregated resource information
 type ClusterCapacity struct {
 	TotalCPU    resource.Quantity
 	TotalMemory resource.Quantity
 	NodeCount   int
-	Profile     ResourceProfile
+	Profile     types.ResourceProfile
 }
 
 // detectClusterProfile analyzes the cluster nodes to determine the resource profile
@@ -65,11 +57,11 @@ func detectClusterProfile(ctx context.Context, client kubernetes.Interface, logg
 	cpuMillis := totalCPU.MilliValue()
 
 	if memBytes < 4*1024*1024*1024 || cpuMillis < 2000 {
-		capacity.Profile = ProfileLow
+		capacity.Profile = types.ProfileLow
 	} else if memBytes < 8*1024*1024*1024 {
-		capacity.Profile = ProfileMedium
+		capacity.Profile = types.ProfileMedium
 	} else {
-		capacity.Profile = ProfileHigh
+		capacity.Profile = types.ProfileHigh
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/internal/components/tuning.go
+++ b/internal/components/tuning.go
@@ -2,10 +2,12 @@ package components
 
 import (
 	"fmt"
+
+	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 )
 
 // getPrometheusValues returns tuned Helm values for kube-prometheus-stack based on profile
-func (m *Manager) getPrometheusValues(profile ResourceProfile) map[string]interface{} {
+func (m *Manager) getPrometheusValues(profile types.ResourceProfile) map[string]interface{} {
 	// Base values
 	values := map[string]interface{}{
 		"prometheus": map[string]interface{}{
@@ -121,7 +123,7 @@ func (m *Manager) getPrometheusValues(profile ResourceProfile) map[string]interf
 	}
 
 	// Tune based on profile
-	if profile == ProfileLow {
+	if profile == types.ProfileLow {
 		m.logger.Info("Applying Low Profile tuning for Prometheus stack")
 
 		// Prometheus Resource Limits
@@ -155,7 +157,7 @@ func (m *Manager) getPrometheusValues(profile ResourceProfile) map[string]interf
 			"requests": map[string]interface{}{"cpu": "50m", "memory": "64Mi"},
 			"limits":   map[string]interface{}{"cpu": "200m", "memory": "128Mi"},
 		}
-	} else if profile == ProfileMedium {
+	} else if profile == types.ProfileMedium {
 		// Medium profile standard defaults (can be tuned if needed)
 		// Usually Helm chart defaults are fine for medium, but explicit limits are safer
 		values["prometheus"].(map[string]interface{})["prometheusSpec"].(map[string]interface{})["resources"] = map[string]interface{}{
@@ -168,7 +170,7 @@ func (m *Manager) getPrometheusValues(profile ResourceProfile) map[string]interf
 }
 
 // getLokiValues returns tuned Helm values for Loki based on profile
-func (m *Manager) getLokiValues(profile ResourceProfile) map[string]interface{} {
+func (m *Manager) getLokiValues(profile types.ResourceProfile) map[string]interface{} {
 	values := map[string]interface{}{
 		"loki": map[string]interface{}{
 			"enabled": true,
@@ -201,7 +203,7 @@ func (m *Manager) getLokiValues(profile ResourceProfile) map[string]interface{} 
 		},
 	}
 
-	if profile == ProfileLow {
+	if profile == types.ProfileLow {
 		m.logger.Info("Applying Low Profile tuning for Loki stack")
 
 		// Loki Resource Limits
@@ -223,7 +225,7 @@ func (m *Manager) getLokiValues(profile ResourceProfile) map[string]interface{} 
 }
 
 // getCertManagerValues returns tuned Helm values for cert-manager based on profile
-func (m *Manager) getCertManagerValues(profile ResourceProfile) map[string]interface{} {
+func (m *Manager) getCertManagerValues(profile types.ResourceProfile) map[string]interface{} {
 	values := map[string]interface{}{
 		"installCRDs": m.stack.CertManager.InstallCRDs,
 		"global": map[string]interface{}{
@@ -233,7 +235,7 @@ func (m *Manager) getCertManagerValues(profile ResourceProfile) map[string]inter
 		},
 	}
 
-	if profile == ProfileLow {
+	if profile == types.ProfileLow {
 		m.logger.Info("Applying Low Profile tuning for cert-manager")
 		// Very conservative limits for Low profile
 		values["resources"] = map[string]interface{}{

--- a/internal/ingress/traefik.go
+++ b/internal/ingress/traefik.go
@@ -1,0 +1,136 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pipeops/pipeops-vm-agent/internal/helm"
+	"github.com/pipeops/pipeops-vm-agent/pkg/types"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TraefikController manages the Traefik ingress controller installation
+type TraefikController struct {
+	installer    *helm.HelmInstaller
+	logger       *logrus.Logger
+	namespace    string
+	chartRepo    string
+	chartName    string
+	releaseName  string
+}
+
+// NewTraefikController creates a new Traefik controller manager
+func NewTraefikController(installer *helm.HelmInstaller, logger *logrus.Logger) *TraefikController {
+	return &TraefikController{
+		installer:   installer,
+		logger:      logger,
+		namespace:   "kube-system", // Traefik is often in kube-system (e.g. k3s default), but we can configure this
+		chartRepo:   "https://traefik.github.io/charts",
+		chartName:   "traefik/traefik",
+		releaseName: "traefik",
+	}
+}
+
+// IsInstalled checks if Traefik is already installed
+func (tc *TraefikController) IsInstalled(ctx context.Context) bool {
+	// Check for deployment in kube-system (common) or default namespace
+	namespaces := []string{"kube-system", "traefik", "default", "ingress-nginx"} // Check common namespaces
+	
+	for _, ns := range namespaces {
+		_, err := tc.installer.K8sClient.AppsV1().Deployments(ns).Get(ctx, tc.releaseName, metav1.GetOptions{})
+		if err == nil {
+			tc.logger.WithField("namespace", ns).Info("Detected existing Traefik installation")
+			tc.namespace = ns // Update namespace to where we found it
+			return true
+		}
+	}
+	return false
+}
+
+// Install installs or upgrades Traefik
+func (tc *TraefikController) Install(ctx context.Context, profile types.ResourceProfile) error {
+	tc.logger.Info("Installing/Upgrading Traefik Ingress Controller...")
+
+	// Add Helm repository
+	if err := tc.installer.AddRepo(ctx, "traefik", tc.chartRepo); err != nil {
+		return fmt.Errorf("failed to add traefik helm repo: %w", err)
+	}
+
+	// Base values
+	values := map[string]interface{}{
+		"deployment": map[string]interface{}{
+			"enabled": true,
+			"replicas": 1,
+		},
+		"providers": map[string]interface{}{
+			"kubernetesCRD": map[string]interface{}{
+				"enabled": true,
+			},
+			"kubernetesIngress": map[string]interface{}{
+				"enabled": true,
+				"publishedService": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+		},
+		"ports": map[string]interface{}{
+			"web": map[string]interface{}{
+				"redirectTo": "websecure",
+			},
+			"websecure": map[string]interface{}{
+				"tls": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+		},
+		"service": map[string]interface{}{
+			"enabled": true,
+			"type": "LoadBalancer", // Default for most cloud/local clusters
+		},
+		// Ensure prometheus metrics are enabled if we want to monitor it later
+		"metrics": map[string]interface{}{
+			"prometheus": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}
+
+	// Tune based on resource profile
+	if profile == types.ProfileLow {
+		tc.logger.Info("Applying Low Profile tuning for Traefik")
+		values["resources"] = map[string]interface{}{
+			"requests": map[string]interface{}{"cpu": "50m", "memory": "64Mi"},
+			"limits":   map[string]interface{}{"cpu": "300m", "memory": "128Mi"},
+		}
+	} else {
+		// Medium/High profile defaults
+		values["resources"] = map[string]interface{}{
+			"requests": map[string]interface{}{"cpu": "100m", "memory": "128Mi"},
+			"limits":   map[string]interface{}{"cpu": "500m", "memory": "256Mi"},
+		}
+	}
+
+	// Install the chart
+	release := &helm.HelmRelease{
+		Name:      tc.releaseName,
+		Namespace: tc.namespace,
+		Chart:     tc.chartName,
+		Repo:      tc.chartRepo,
+		Version:   "", // Use latest stable
+		Values:    values,
+	}
+
+	if err := tc.installer.Install(ctx, release); err != nil {
+		return fmt.Errorf("failed to install Traefik: %w", err)
+	}
+
+	tc.logger.Info("✓ Traefik Ingress Controller installed/upgraded successfully")
+	return nil
+}
+
+// Uninstall removes Traefik
+func (tc *TraefikController) Uninstall(ctx context.Context) error {
+	tc.logger.Info("Uninstalling Traefik...")
+	return tc.installer.Uninstall(ctx, tc.releaseName, tc.namespace)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -724,6 +724,15 @@ type TunnelProtocolDiscovery struct {
 	GatewayLabel string `yaml:"gateway_label" mapstructure:"gateway_label"`
 }
 
+// ResourceProfile represents the capability level of the cluster
+type ResourceProfile string
+
+const (
+	ProfileLow    ResourceProfile = "low"    // < 4GB RAM or < 2 CPUs (Minimal install, serial)
+	ProfileMedium ResourceProfile = "medium" // 4GB-8GB RAM (Standard install)
+	ProfileHigh   ResourceProfile = "high"   // > 8GB RAM (Performance install)
+)
+
 // TCPTunnelProtocolConfig represents TCP-specific tunnel configuration
 type TCPTunnelProtocolConfig struct {
 	BufferSize        int           `yaml:"buffer_size" mapstructure:"buffer_size"`               // Read/write buffer size (default: 32768)


### PR DESCRIPTION
This pull request introduces a major update to the ingress controller management by migrating from NGINX to Traefik and refactors the resource profile logic to use a shared type from the `pkg/types` package. The changes streamline profile handling across the codebase and improve the ingress controller installation and migration process, including enhanced detection and migration logic.

**Ingress Controller Migration and Management:**

* Replaces the NGINX ingress controller with Traefik: adds a `TraefikController` to the `Manager`, updates the installation logic to uninstall NGINX if present, and installs/upgrades Traefik instead. The installation step now checks for existing controllers and handles migration, including waiting for port release after uninstalling NGINX. (`internal/components/manager.go`) [[1]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R115) [[2]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R134-R136) [[3]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77R149) [[4]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77L188-R232)
* Updates ingress preference detection to allow replacing NGINX or updating Traefik, only skipping bundled ingress installation if a third-party ingress class is detected. Removes old deployment checks for NGINX/Traefik. (`internal/components/manager.go`)

**Resource Profile Refactoring:**

* Refactors the `ResourceProfile` type and constants to be imported from `pkg/types`, replacing local definitions and updating all usages throughout the codebase for consistency. (`internal/components/manager.go`, `internal/components/orchestrator.go`, `internal/components/resources.go`, `internal/components/tuning.go`) [[1]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77L155-R161) [[2]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77L886-R908) [[3]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77L918-R940) [[4]](diffhunk://#diff-6a4930ab45c0cf948f1c48c4e6c92f4cb36f5df4cd258e208aa63173ec79fa77L941-R963) [[5]](diffhunk://#diff-33c36b67023fabb5a2bac3c95517adb65f9fe004ca15f6b650764c8340a00fadR8) [[6]](diffhunk://#diff-33c36b67023fabb5a2bac3c95517adb65f9fe004ca15f6b650764c8340a00fadL23-R24) [[7]](diffhunk://#diff-33c36b67023fabb5a2bac3c95517adb65f9fe004ca15f6b650764c8340a00fadL48-R54) [[8]](diffhunk://#diff-33c36b67023fabb5a2bac3c95517adb65f9fe004ca15f6b650764c8340a00fadL62-R63) [[9]](diffhunk://#diff-33c36b67023fabb5a2bac3c95517adb65f9fe004ca15f6b650764c8340a00fadL92-R93) [[10]](diffhunk://#diff-b95077254ff64d343f9cc408ca46af282306c7f8e82d1c777d7b2dcebea18344R7-R20) [[11]](diffhunk://#diff-b95077254ff64d343f9cc408ca46af282306c7f8e82d1c777d7b2dcebea18344L68-R64) [[12]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33R5-R10) [[13]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33L124-R126) [[14]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33L158-R160) [[15]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33L171-R173) [[16]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33L204-R206) [[17]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33L226-R228) [[18]](diffhunk://#diff-42bf1f01e840263cc27abe0ac4d32b5de84723d8f6bd24ed803b554e9c6e4d33L236-R238)