### PR TITLE
fix: increase websocket ping frequency to prevent unexpected EOF

### DIFF
--- a/pkg/types/timeouts.go
+++ b/pkg/types/timeouts.go
@@ -43,7 +43,7 @@ func DefaultTimeouts() *Timeouts {
 	return &Timeouts{
 		// WebSocket timeouts
 		WebSocketHandshake:    30 * time.Second, // Increased from 10s to handle slow connections
-		WebSocketPing:         30 * time.Second,
+		WebSocketPing:         10 * time.Second, // Increased frequency (was 30s) to keep NAT/LB alive
 		WebSocketRead:         60 * time.Second,       // 2x ping interval
 		WebSocketReconnect:    500 * time.Millisecond, // Fast initial reconnect
 		WebSocketReconnectMax: 15 * time.Second,       // Cap for sustained outages


### PR DESCRIPTION
This pull request makes a minor adjustment to the WebSocket timeout settings to improve connection reliability. Specifically, it increases the frequency of WebSocket ping messages to help keep NAT devices and load balancers from closing idle connections.

- WebSocket timeouts:
  * [`pkg/types/timeouts.go`](diffhunk://#diff-54e86febe8c70a7c57b22c9027b29a6bb64c052260785f630c09945637892869L46-R46): Reduced the `WebSocketPing` interval from 30 seconds to 10 seconds to increase ping frequency and maintain connections through NAT/LB devices.