### PR TITLE
fix: make monitoring components non-critical and add profile-aware Helm timeouts

### DIFF
--- a/internal/ingress/traefik.go
+++ b/internal/ingress/traefik.go
@@ -100,6 +100,7 @@ func (tc *TraefikController) Install(ctx context.Context, profile types.Resource
 		Repo:      tc.chartRepo,
 		Version:   "v33.1.0",
 		Values:    values,
+		Timeout:   traefikHelmTimeout(profile),
 	}
 
 	if err := tc.installer.Install(ctx, release); err != nil {
@@ -121,6 +122,14 @@ func (tc *TraefikController) Install(ctx context.Context, profile types.Resource
 	}
 
 	return nil
+}
+
+// traefikHelmTimeout returns a profile-aware timeout for Traefik Helm operations.
+func traefikHelmTimeout(profile types.ResourceProfile) time.Duration {
+	if profile == types.ProfileLow {
+		return 10 * time.Minute
+	}
+	return 15 * time.Minute
 }
 
 // buildBaseValues returns the Helm values for Traefik without middleware references.
@@ -204,6 +213,7 @@ func (tc *TraefikController) setupErrorPages(ctx context.Context, profile types.
 		Repo:      tc.chartRepo,
 		Version:   "v33.1.0",
 		Values:    values,
+		Timeout:   traefikHelmTimeout(profile),
 	}
 
 	if err := tc.installer.Install(ctx, release); err != nil {


### PR DESCRIPTION
## Summary

- **Make Traefik and Prometheus non-critical** (`Critical: false`) so all monitoring components are attempted regardless of individual Helm install failures
- **Add profile-aware Helm timeouts**: 10 minutes for low-resource profiles, 15 minutes for medium/high
- **Improve installation plan logging**: track failed components, log skipped steps on critical failure, and summarize results at the end

## Problem

On low-resource Proxmox LXC containers (1 vCPU / 2.5GB RAM), Traefik's Helm install times out because CPU is saturated. Since Traefik was marked `Critical: true`, the timeout caused `executeInstallationPlan()` to abort immediately — **Prometheus and Loki were never attempted**.

The installation plan is serial: cert-manager → Traefik → Prometheus → Loki. Any critical step failure aborts everything after it.

## Changes

### `internal/helm/installer.go`
- Added `Timeout time.Duration` field to `HelmRelease` struct
- Added `defaultHelmTimeout` constant (15 min) and `resolveTimeout()` helper
- Updated `install()`, `upgrade()`, and `upgradeWithForce()` to use `resolveTimeout(release)` instead of a hardcoded 15-minute timeout

### `internal/components/manager.go`
- Changed Traefik `Critical: true` → `Critical: false`
- Changed Prometheus `Critical: true` → `Critical: false`
- Added `helmTimeout(profile)` helper: returns 10 min for `ResourceProfileLow`, 15 min for medium/high
- All `HelmRelease` structs (Prometheus, Loki, cert-manager) now pass `Timeout: helmTimeout(profile)`

### `internal/ingress/traefik.go`
- Added `traefikHelmTimeout()` helper (10 min low, 15 min medium/high)
- Both Phase 1 and Phase 2 `HelmRelease` objects now pass `Timeout: traefikHelmTimeout(profile)`

### `internal/components/orchestrator.go`
- `executeInstallationPlan()` now tracks a `failedComponents` slice and logs a summary at the end
- Critical step failures log the names of all skipped remaining steps before aborting
- Non-critical failures log the count of remaining steps that will still be attempted

## Testing

All tests pass: `go test ./...` and `go vet ./...` clean.