### PR TITLE
Feat/response streaming

### DIFF
--- a/internal/tunnel/wsconn.go
+++ b/internal/tunnel/wsconn.go
@@ -9,75 +9,79 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// WSConn wraps a WebSocket connection to implement net.Conn
-// This adapter is required for yamux which expects a net.Conn interface
+// WSConn wraps a WebSocket connection to implement net.Conn for yamux.
+//
+// Single-WS architecture: The main read loop owns ws.ReadMessage() and demuxes
+// text (JSON control) vs binary (yamux) frames. Binary frame data is fed into
+// this adapter via FeedBinaryData(). Read() pulls from an internal pipe.
+// Write() sends binary frames directly to the WebSocket (mutex-protected).
+//
+// This design allows yamux and the JSON control protocol to share a single
+// WebSocket connection without fighting over NextReader().
+//
+// IMPORTANT: The writeMu must be the same mutex used by the caller for text
+// writes (e.g., WebSocketClient.writeMutex) to prevent concurrent writes to
+// the underlying WebSocket connection, which gorilla/websocket does not support.
 type WSConn struct {
-	ws       *websocket.Conn
-	reader   io.Reader
-	readerMu sync.Mutex
-	writeMu  sync.Mutex
-	closed   bool
-	closedMu sync.RWMutex
+	ws *websocket.Conn
+
+	// Pipe for binary data: the main read loop writes binary frame data into
+	// pipeWriter, and Read() consumes it from pipeReader.
+	pipeReader *io.PipeReader
+	pipeWriter *io.PipeWriter
+
+	// Write mutex — shared with the caller so text (JSON) and binary (yamux)
+	// writes to the same WebSocket are properly serialized.
+	writeMu *sync.Mutex
+
+	closed  bool
+	closeMu sync.RWMutex
 }
 
-// NewWSConn creates a new WSConn wrapping a WebSocket connection
-func NewWSConn(ws *websocket.Conn) *WSConn {
-	return &WSConn{ws: ws}
+// NewWSConn creates a new WSConn wrapping a WebSocket connection.
+// Binary data must be fed via FeedBinaryData() from the main read loop.
+// writeMu MUST be the same mutex the caller uses for text/JSON writes to ws,
+// since gorilla/websocket does not support concurrent writers.
+func NewWSConn(ws *websocket.Conn, writeMu *sync.Mutex) *WSConn {
+	pr, pw := io.Pipe()
+	return &WSConn{
+		ws:         ws,
+		pipeReader: pr,
+		pipeWriter: pw,
+		writeMu:    writeMu,
+	}
 }
 
-// Read implements io.Reader for the WebSocket connection
-// It reads binary messages from the WebSocket and returns them as a byte stream
+// FeedBinaryData pushes binary WebSocket frame data into the pipe for yamux to consume.
+// Called by the main read loop when it receives a BinaryMessage.
+// Returns an error if the pipe is closed (WSConn was closed).
+func (c *WSConn) FeedBinaryData(data []byte) error {
+	_, err := c.pipeWriter.Write(data)
+	return err
+}
+
+// Read implements io.Reader / net.Conn.Read.
+// It reads from the internal pipe that is fed by the main read loop's demuxer.
 func (c *WSConn) Read(b []byte) (int, error) {
-	c.closedMu.RLock()
-	if c.closed {
-		c.closedMu.RUnlock()
-		return 0, io.EOF
-	}
-	c.closedMu.RUnlock()
-
-	c.readerMu.Lock()
-	defer c.readerMu.Unlock()
-
-	for {
-		if c.reader != nil {
-			n, err := c.reader.Read(b)
-			if err == io.EOF {
-				c.reader = nil
-				if n > 0 {
-					return n, nil
-				}
-				continue
-			}
-			return n, err
-		}
-
-		messageType, reader, err := c.ws.NextReader()
-		if err != nil {
-			return 0, err
-		}
-
-		// Only handle binary messages for yamux
-		if messageType != websocket.BinaryMessage {
-			io.Copy(io.Discard, reader)
-			continue
-		}
-
-		c.reader = reader
-	}
+	return c.pipeReader.Read(b)
 }
 
-// Write implements io.Writer for the WebSocket connection
-// It sends data as binary WebSocket messages
+// Write implements io.Writer / net.Conn.Write.
+// It sends data as a binary WebSocket frame directly.
 func (c *WSConn) Write(b []byte) (int, error) {
-	c.closedMu.RLock()
+	c.closeMu.RLock()
 	if c.closed {
-		c.closedMu.RUnlock()
+		c.closeMu.RUnlock()
 		return 0, io.ErrClosedPipe
 	}
-	c.closedMu.RUnlock()
+	c.closeMu.RUnlock()
 
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
+
+	if err := c.ws.SetWriteDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		// Non-fatal — continue with write attempt
+	}
 
 	err := c.ws.WriteMessage(websocket.BinaryMessage, b)
 	if err != nil {
@@ -86,22 +90,23 @@ func (c *WSConn) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// Close closes the WebSocket connection
+// Close closes the pipe and marks the connection as closed.
+// It does NOT close the underlying WebSocket — that is owned by the main
+// connection lifecycle (handleConnection / readMessages).
 func (c *WSConn) Close() error {
-	c.closedMu.Lock()
+	c.closeMu.Lock()
 	if c.closed {
-		c.closedMu.Unlock()
+		c.closeMu.Unlock()
 		return nil
 	}
 	c.closed = true
-	c.closedMu.Unlock()
+	c.closeMu.Unlock()
 
-	c.writeMu.Lock()
-	c.ws.WriteMessage(websocket.CloseMessage,
-		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-	c.writeMu.Unlock()
+	// Close the pipe — unblocks any pending Read() and FeedBinaryData()
+	c.pipeWriter.Close()
+	c.pipeReader.Close()
 
-	return c.ws.Close()
+	return nil
 }
 
 // LocalAddr returns the local network address
@@ -116,15 +121,15 @@ func (c *WSConn) RemoteAddr() net.Addr {
 
 // SetDeadline sets both read and write deadlines
 func (c *WSConn) SetDeadline(t time.Time) error {
-	if err := c.ws.SetReadDeadline(t); err != nil {
-		return err
-	}
-	return c.ws.SetWriteDeadline(t)
+	// Deadlines on the pipe are not directly supported.
+	// yamux handles its own timeouts internally.
+	return nil
 }
 
 // SetReadDeadline sets the read deadline
 func (c *WSConn) SetReadDeadline(t time.Time) error {
-	return c.ws.SetReadDeadline(t)
+	// Not applicable for pipe-based reads — yamux manages timeouts.
+	return nil
 }
 
 // SetWriteDeadline sets the write deadline
@@ -134,7 +139,10 @@ func (c *WSConn) SetWriteDeadline(t time.Time) error {
 
 // IsClosed returns whether the connection is closed
 func (c *WSConn) IsClosed() bool {
-	c.closedMu.RLock()
-	defer c.closedMu.RUnlock()
+	c.closeMu.RLock()
+	defer c.closeMu.RUnlock()
 	return c.closed
 }
+
+// Ensure WSConn implements net.Conn at compile time
+var _ net.Conn = (*WSConn)(nil)

--- a/internal/tunnel/yamux_client.go
+++ b/internal/tunnel/yamux_client.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/hashicorp/yamux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -88,10 +87,9 @@ type YamuxTunnelClient struct {
 	activeStreams int64
 }
 
-// NewYamuxTunnelClient creates a new yamux tunnel client
-func NewYamuxTunnelClient(clusterUUID string, ws *websocket.Conn, config YamuxConfig, logger *logrus.Logger) (*YamuxTunnelClient, error) {
-	wsConn := NewWSConn(ws)
-
+// NewYamuxTunnelClient creates a new yamux tunnel client on a shared WSConn.
+// Single-WS architecture: the WSConn is pipe-fed by the main read loop.
+func NewYamuxTunnelClient(clusterUUID string, wsConn *WSConn, config YamuxConfig, logger *logrus.Logger) (*YamuxTunnelClient, error) {
 	// Configure yamux - agent is CLIENT (accepts streams from gateway SERVER)
 	yamuxCfg := yamux.DefaultConfig()
 	yamuxCfg.AcceptBacklog = config.AcceptBacklog


### PR DESCRIPTION
This pull request refactors the WebSocket and yamux tunnel integration to enable a "single-WS" architecture, where both JSON control messages and yamux binary frames share a single WebSocket connection. The main read loop demuxes incoming frames, feeding binary data to yamux via a pipe-fed adapter, and text messages to the control protocol. This change improves resource efficiency and simplifies connection management, and is accompanied by updates to the `WSConn` adapter and related lifecycle handling.

### Single-WS architecture for yamux and control protocol

* Refactored `WebSocketClient` to demux text (JSON control) and binary (yamux) frames in a unified `readMessages()` loop, feeding binary data to yamux via `WSConn.FeedBinaryData()` and handling text messages as before. (`internal/controlplane/websocket_client.go`) [[1]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebL706-R719) [[2]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebL723-R736) [[3]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebL735-R778)
* Updated `handleGatewayHello` to send a `gateway_hello_ack` and start yamux on the existing control WebSocket using a pipe-fed `WSConn`, rather than requiring a separate connection. (`internal/controlplane/websocket_client.go`) [[1]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebL2663-R2701) [[2]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebL2692-R2764)

### `WSConn` adapter improvements

* Redesigned `WSConn` to use an internal pipe for binary data, fed by the main read loop, and to share a write mutex with text message writers for safe concurrent access. (`internal/tunnel/wsconn.go`)
* Updated `WSConn` lifecycle methods (`Read`, `Write`, `Close`) to operate on the pipe and avoid closing the underlying WebSocket, which is managed by the main connection lifecycle. (`internal/tunnel/wsconn.go`) [[1]](diffhunk://#diff-d7321e53d747aa50fb9514303e9d37e48c797cd29c638ade5f3fba8f61e1ce3bL12-R109) [[2]](diffhunk://#diff-d7321e53d747aa50fb9514303e9d37e48c797cd29c638ade5f3fba8f61e1ce3bL119-R132)
* Ensured `WSConn` implements `net.Conn` and clarified deadline handling for yamux. (`internal/tunnel/wsconn.go`)

### Connection and client lifecycle

* Modified `WebSocketClient` to properly stop and clean up the yamux client and associated pipe-fed `WSConn` during reconnects and closure, preventing resource leaks. (`internal/controlplane/websocket_client.go`) [[1]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebR295-R299) [[2]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebR679-R683) [[3]](diffhunk://#diff-96db0c85e0e181de8ddedfd14adbf0aaad550682b2977c036f007f397b5bb2ebL2725-R2838)

### Test updates

* Updated all `WSConn` tests to use the new constructor signature and simulate the single-WS demuxing pattern, ensuring correctness for read/write, close, and large message scenarios. (`internal/tunnel/wsconn_test.go`) [[1]](diffhunk://#diff-410ae31c2ee6593c1ba1a549c9a5f374ead14f819a5c89fe839fba8adfc5a4f0L49-R75) [[2]](diffhunk://#diff-410ae31c2ee6593c1ba1a549c9a5f374ead14f819a5c89fe839fba8adfc5a4f0L84-R97) [[3]](diffhunk://#diff-410ae31c2ee6593c1ba1a549c9a5f374ead14f819a5c89fe839fba8adfc5a4f0L109-R129) [[4]](diffhunk://#diff-410ae31c2ee6593c1ba1a549c9a5f374ead14f819a5c89fe839fba8adfc5a4f0L130-R146) [[5]](diffhunk://#diff-410ae31c2ee6593c1ba1a549c9a5f374ead14f819a5c89fe839fba8adfc5a4f0L151-R168) [[6]](diffhunk://#diff-410ae31c2ee6593c1ba1a549c9a5f374ead14f819a5c89fe839fba8adfc5a4f0L192-R233)

These changes collectively enable efficient sharing of a single WebSocket for both control and yamux traffic, improving scalability and reducing connection complexity.