### PR TITLE
feat: single-WS yamux multiplexing, response streaming, and Phase 1-4 documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ The PipeOps Kubernetes Agent is a background service that:
 - **PipeOps Integration** - Seamlessly connects your infrastructure to the PipeOps platform for secure management
 - **Automated Setup** - Handles Kubernetes installation, configuration, and management automatically  
 - **Secure Access** - Provides secure admin access via WebSocket tunnel (no inbound ports required)
+- **TCP/UDP Tunneling** - Expose databases, caches, and other TCP/UDP services securely through yamux-multiplexed tunnels
 - **Project Deployment** - Enables easy deployment of applications and services through PipeOps
 - **Infrastructure Management** - Manages server resources, networking, and scaling automatically
 - **Smart Gateway Proxy** - Automatic ingress management with intelligent routing (tunnel for private, direct for public clusters)
@@ -25,6 +26,8 @@ The PipeOps Kubernetes Agent is a background service that:
 
 - **One-Click Server Setup** - Transform any VM into a deployment-ready server in minutes
 - **Secure Cluster Access** - WebSocket tunnel for secure admin access without inbound firewall rules
+- **Yamux L4 Tunneling** - Multiplex TCP/UDP connections (PostgreSQL, Redis, SSH, etc.) over the existing WebSocket with yamux
+- **Response Streaming** - Incremental streaming of large HTTP proxy responses to reduce memory pressure
 - **Comprehensive Monitoring** - Built-in monitoring stack with Grafana, Prometheus, and Loki (optional)
 - **Secure Communications** - Encrypted connections to PipeOps platform with enterprise-grade security
 - **PipeOps Gateway Proxy** - Automatic ingress route discovery with smart routing detection (enabled by default)
@@ -98,10 +101,12 @@ Transform your VM into a deployment server in a few steps:
 
 !!! tip "Latest Updates"
 
+    - **Yamux L4 Tunneling**: Single-WebSocket TCP/UDP multiplexing via yamux — expose PostgreSQL, Redis, SSH securely
+    - **Response Streaming**: Large HTTP proxy responses streamed incrementally instead of buffered in memory
+    - **WebSocket Stability**: Heartbeat monitoring, upgrade detection fixes, improved connection lifecycle
     - **v2.1.0**: Enhanced monitoring with custom metrics support
     - **Multi-arch support**: Now supports ARM64 and x86_64 architectures (works on Raspberry Pi!)
     - **Improved security**: mTLS encryption for all communications with PipeOps platform
-    - **Better automation**: Fully automated Kubernetes setup and configuration
 
 ## Supported Virtual Machine Platforms
 
@@ -181,10 +186,13 @@ graph TB
     D --> G[Loki]
     B --> H[Tunnel Manager]
     H --> I[WebSocket Connection]
+    I -->|Text: JSON Control| J[Heartbeat / Proxy / Registration]
+    I -->|Binary: Yamux Frames| K[L4 TCP/UDP Tunnels]
 ```
 
 - **Agent Core**: Main orchestration engine
-- **Tunnel Manager**: Secure communication with control plane
+- **Tunnel Manager**: Secure communication with control plane via single WebSocket
+- **Yamux Multiplexing**: TCP/UDP streams multiplexed as binary frames over the control WebSocket
 - **Monitoring Stack**: Observability and metrics collection
 - **Kubernetes Integration**: Native K8s resource management
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -12,10 +12,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete MkDocs configuration with dark/light mode support
 - Comprehensive command reference documentation
 - Improved troubleshooting guides
+- **Single-WebSocket yamux multiplexing for L4 TCP/UDP tunneling** (Phase 3)
+  - Text/binary message type multiplexing on the existing `/ws` control connection
+  - Pipe-fed `WSConn` adapter bridges yamux over the shared WebSocket
+  - `gateway_hello` / `gateway_hello_ack` negotiation protocol
+  - Gateway is yamux server (opens streams), agent is yamux client (accepts streams)
+  - Enabled by default (`AGENT_ENABLE_L4_TUNNEL=true`, `ENABLE_YAMUX_TUNNELS=true`)
+- **Response streaming protocol for proxied HTTP requests** (Phase 2)
+  - New `proxy_response_start`, `proxy_response_chunk`, `proxy_response_end` message types
+  - Streams large responses incrementally instead of buffering entire body in memory
+  - Reduces memory pressure for large file downloads and API responses
+- **WebSocket heartbeat and connection stability improvements** (Phase 1)
+  - Ping/pong heartbeat monitoring with configurable intervals
+  - WebSocket upgrade detection bug fixes for tunnel proxy path
+  - Improved connection lifecycle management and graceful shutdown
 
 ### Changed
 - Updated MkDocs theme to Material Design with indigo color scheme
 - Reorganized documentation structure for better navigation
+- `AGENT_ENABLE_L4_TUNNEL` default changed from `false` to `true`
+- Renamed `TunnelStreamHeader` methods from `WriteTo`/`ReadFrom` to `Encode`/`Decode` to fix `go vet` warnings (controller-side)
+
+### Fixed
+- **WebSocket upgrade detection in tunnel proxy** — requests with `Connection: Upgrade` headers are now correctly identified and proxied as WebSocket connections instead of plain HTTP (Phase 1)
+- **Heartbeat stability** — fixed race conditions in ping/pong handler registration that could cause missed heartbeats (Phase 1)
+- **Response buffering for large payloads** — replaced full-body buffering with streaming to prevent OOM on large proxy responses (Phase 2)
 
 ### Performance
 - **Improved agent reconnection speed by 60%+** for extended control plane outages


### PR DESCRIPTION
## Summary

- **Rework yamux from dual-WS to single-WS architecture**: Text/binary message type multiplexing on the existing `/ws` control connection — text messages carry JSON control protocol, binary messages carry yamux frames. Pipe-fed `WSConn` adapter with shared write mutex for serialized writes.
- **Add response streaming protocol**: New `proxy_response_start`, `proxy_response_chunk`, `proxy_response_end` message types stream large HTTP proxy responses incrementally instead of buffering entire bodies in memory.
- **Update all documentation to reflect Phase 1-3 changes**: README, ARCHITECTURE, changelog, index, tcp-udp-tunneling, controlplane README, and websocket README updated with yamux single-WS design, response streaming, heartbeat fixes, and corrected config defaults.

## Changes

### Code (`ce0042e` — single-WS yamux rework)
- `internal/controlplane/websocket_client.go`: Read loop demuxer (text→JSON, binary→`FeedBinaryData()`), `gateway_hello`/`gateway_hello_ack` negotiation, shared write mutex for concurrent text+binary writes
- `internal/controlplane/types.go`: New message types for streaming and yamux negotiation
- `internal/tunnel/wsconn.go`: Pipe-fed `WSConn` adapter — `FeedBinaryData()` writes to `io.PipeWriter`, yamux reads from `io.PipeReader`; `Write()` sends binary frames; `Close()` closes only the pipe, not the underlying WS
- `internal/tunnel/wsconn_test.go`: Updated tests for pipe-fed model
- `internal/tunnel/yamux_client.go`: Minor adjustments for single-WS integration

### Code (`1df3d09` — response streaming)
- `internal/controlplane/websocket_client.go`: Streaming response handler
- `internal/controlplane/websocket_streaming_response_test.go`: New test file (469 lines) covering the streaming protocol

### Documentation (`e255dcc`)
- `README.md`: Added yamux, L4 tunnel, response streaming to features; updated config defaults
- `docs/ARCHITECTURE.md`: Yamux negotiation diagram, WSConn explanation, updated communication channels
- `docs/advanced/tcp-udp-tunneling.md`: Single-WS yamux clarification
- `docs/index.md`: Added yamux/L4 and response streaming to Key Features and What's New
- `docs/reference/changelog.md`: Phase 1-3 changelog entries under `[Unreleased]`
- `internal/controlplane/README.md`: New message types, text/binary demuxer, streaming protocol
- `internal/websocket/README.md`: L4 tunnel marked as "Fully Implemented", cleaned up Future Enhancements

## Testing
- `go test -v ./internal/tunnel/...` — WSConn pipe-fed tests pass
- `go test -v ./internal/controlplane/...` — streaming response tests pass
- `go test -v -race ./...` — full test suite passes with race detector

## Related
- Companion controller PR: #5520 (`pipeops-controller` repo, branch `feat/dual-ws-yamux`)
- Previous merged PR: #99 (initial yamux client implementation)
- Merged Phase 1 PR: #97 (WebSocket heartbeat/upgrade fixes)