### PR TITLE
fix: inject default K8s subprotocols for exec/attach/portforward WebSocket connections

### DIFF
--- a/internal/controlplane/websocket_proxy_test.go
+++ b/internal/controlplane/websocket_proxy_test.go
@@ -229,3 +229,69 @@ func TestExtractWebSocketSubprotocols(t *testing.T) {
 		})
 	}
 }
+
+func TestIsK8sStreamingPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "exec endpoint",
+			path: "/api/v1/namespaces/default/pods/my-pod/exec",
+			want: true,
+		},
+		{
+			name: "attach endpoint",
+			path: "/api/v1/namespaces/default/pods/my-pod/attach",
+			want: true,
+		},
+		{
+			name: "portforward endpoint",
+			path: "/api/v1/namespaces/default/pods/my-pod/portforward",
+			want: true,
+		},
+		{
+			name: "exec with query params path segment",
+			path: "/api/v1/namespaces/kube-system/pods/coredns-abc123/exec",
+			want: true,
+		},
+		{
+			name: "regular pod list",
+			path: "/api/v1/namespaces/default/pods",
+			want: false,
+		},
+		{
+			name: "pod logs",
+			path: "/api/v1/namespaces/default/pods/my-pod/log",
+			want: false,
+		},
+		{
+			name: "deployments",
+			path: "/apis/apps/v1/namespaces/default/deployments",
+			want: false,
+		},
+		{
+			name: "empty path",
+			path: "",
+			want: false,
+		},
+		{
+			name: "root path",
+			path: "/",
+			want: false,
+		},
+		{
+			name: "version endpoint",
+			path: "/version",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isK8sStreamingPath(tt.path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes K8s exec "websocket: bad handshake" error caused by missing WebSocket subprotocol negotiation
- Adds `isK8sStreamingPath()` helper to detect exec/attach/portforward endpoints
- Automatically injects `v4.channel.k8s.io` (and v3/v2/channel fallbacks) when no subprotocol is forwarded from the controller/gateway chain
- Improves error logging to include HTTP status code from failed K8s API dials

## Root Cause

The PipeOps frontend (xterm.js) opens a raw WebSocket to the exec endpoint **without** specifying `Sec-WebSocket-Protocol`. The controller and gateway only forward the subprotocol if the client sends one, so the agent dials the K8s API without any subprotocol. Kubernetes exec/attach/portforward endpoints **require** subprotocol negotiation (`v4.channel.k8s.io` etc.), so the API server rejects the upgrade with HTTP 400 → gorilla reports "websocket: bad handshake".

## Changes

### `internal/controlplane/websocket_proxy.go`
- After `extractWebSocketSubprotocols()`, if no subprotocols were extracted AND the path matches an exec/attach/portforward pattern, inject `["v4.channel.k8s.io", "v3.channel.k8s.io", "v2.channel.k8s.io", "channel.k8s.io"]` as defaults
- Changed error log at K8s dial failure to include `errMsg` (with HTTP status code) as a structured field

### `internal/controlplane/websocket_proxy_test.go`
- Added `TestIsK8sStreamingPath` with 10 table-driven test cases covering exec, attach, portforward, and negative cases

## Testing
- All existing tests pass (`go test -v ./...`)
- Lint clean (`go fmt ./... && go vet ./...`)
- Binary builds successfully (`make build`)

## Companion PR
- Controller: PipeOpsHQ/pipeops-controller — belt-and-suspenders fix to inject `Sec-WebSocket-Protocol: v4.channel.k8s.io` in the gateway dial headers when the browser omits it