### PR TITLE
fix: resolve exec 403 auth override and yamux keepalive timeout loop

### DIFF
--- a/internal/tunnel/wsconn.go
+++ b/internal/tunnel/wsconn.go
@@ -79,10 +79,6 @@ func (c *WSConn) Write(b []byte) (int, error) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 
-	if err := c.ws.SetWriteDeadline(time.Now().Add(30 * time.Second)); err != nil {
-		// Non-fatal — continue with write attempt
-	}
-
 	err := c.ws.WriteMessage(websocket.BinaryMessage, b)
 	if err != nil {
 		return 0, err
@@ -132,9 +128,12 @@ func (c *WSConn) SetReadDeadline(t time.Time) error {
 	return nil
 }
 
-// SetWriteDeadline sets the write deadline
+// SetWriteDeadline is a no-op. yamux calls this to manage its own write
+// timeouts, but on a shared WebSocket connection these deadlines persist and
+// conflict with WS-level pings and JSON control writes. Yamux's internal
+// ConnectionWriteTimeout is sufficient.
 func (c *WSConn) SetWriteDeadline(t time.Time) error {
-	return c.ws.SetWriteDeadline(t)
+	return nil
 }
 
 // IsClosed returns whether the connection is closed

--- a/internal/tunnel/yamux_client.go
+++ b/internal/tunnel/yamux_client.go
@@ -68,7 +68,7 @@ func DefaultYamuxConfig() YamuxConfig {
 	return YamuxConfig{
 		MaxStreamWindowSize: 256 * 1024, // 256KB
 		KeepAliveInterval:   30 * time.Second,
-		ConnectionTimeout:   10 * time.Second,
+		ConnectionTimeout:   30 * time.Second,
 		AcceptBacklog:       256,
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two production bugs discovered from agent logs after the subprotocol fix (PR #103) was deployed:

- **Exec 403 Forbidden**: `connectToKubernetes()` unconditionally overrode the `Authorization` header with the in-cluster ServiceAccount token, replacing the gateway-injected `ClusterToken`. Now uses the in-cluster token only as a fallback when the gateway didn't provide one — matching the HTTP proxy behaviour in `agent.go`.
- **Yamux keepalive timeout loop**: Every ~40s yamux died and reconnected due to write mutex contention and stale deadlines. Fixed by removing `SetWriteDeadline` from `Write()`, making `SetWriteDeadline` a no-op on the shared WS adapter, and increasing `ConnectionWriteTimeout` from 10s to 30s.

## Changes

| File | Change |
|------|--------|
| `internal/controlplane/websocket_proxy.go` | Use in-cluster SA token as fallback only when gateway didn't inject `Authorization` |
| `internal/tunnel/wsconn.go` | Remove `SetWriteDeadline` from `Write()`; make `SetWriteDeadline()` a no-op |
| `internal/tunnel/yamux_client.go` | Increase `ConnectionWriteTimeout` from 10s to 30s |

## Companion PR

- Controller: https://github.com/PipeOpsHQ/pipeops-controller/pull/new/fix/exec-auth-yamux-keepalive (gateway-side yamux fixes)

## Testing

- All existing tests pass (`go test -v ./internal/tunnel/ ./internal/controlplane/`)
- Build compiles cleanly, `go vet` and `go fmt` clean