### PR TITLE
fix: clear stale write deadlines on shared WS to prevent yamux keepalive timeout

### DIFF
--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -1584,7 +1584,10 @@ func (c *WebSocketClient) sendMessage(msg *WebSocketMessage) error {
 		c.logger.WithError(err).Debug("Failed to set write deadline for WebSocket message")
 	}
 
-	return conn.WriteJSON(msg)
+	writeErr := conn.WriteJSON(msg)
+	// Clear stale deadline so it doesn't poison subsequent yamux writes on the shared WS
+	conn.SetWriteDeadline(time.Time{})
+	return writeErr
 }
 
 // sendBinaryMessage sends a binary message via WebSocket (for large payloads)
@@ -1605,7 +1608,10 @@ func (c *WebSocketClient) sendBinaryMessage(data []byte) error {
 		c.logger.WithError(err).Debug("Failed to set write deadline for binary WebSocket message")
 	}
 
-	return conn.WriteMessage(websocket.BinaryMessage, data)
+	writeErr := conn.WriteMessage(websocket.BinaryMessage, data)
+	// Clear stale deadline so it doesn't poison subsequent yamux writes on the shared WS
+	conn.SetWriteDeadline(time.Time{})
+	return writeErr
 }
 
 // SendProxyResponseBinary sends a proxy response using binary protocol for large payloads


### PR DESCRIPTION
## Summary

- Clears `SetWriteDeadline` after every `WriteJSON`/`WriteMessage` call in `sendMessage()` and `sendBinaryMessage()` to prevent stale deadlines from poisoning subsequent yamux writes through the shared gorilla WebSocket connection

## Problem

After merging PR #104, yamux keepalive still enters a ~40s timeout loop. The root cause: `sendMessage()` and `sendBinaryMessage()` in `websocket_client.go` call `conn.SetWriteDeadline(10s)` directly on the raw gorilla WS conn before writing. After the write completes, the deadline is left active. When yamux's `sendLoop()` later calls `WSConn.Write()` (which goes through the same raw conn), the stale deadline fires and causes a write timeout — triggering yamux session teardown and reconnect.

## Fix

Add `conn.SetWriteDeadline(time.Time{})` immediately after each successful write to clear the stale deadline. This matches the existing correct pattern in `internal/websocket/heartbeat.go` lines 90-104.

## Affected paths

| Function | Line | Description |
|----------|------|-------------|
| `sendMessage()` | ~1583 | Sets 10s deadline before `WriteJSON`, now clears after |
| `sendBinaryMessage()` | ~1604 | Sets 10s deadline before `WriteMessage`, now clears after |

## Testing

- `make test` passes
- `make lint` passes
- Companion controller PR with the same fix for gateway-side write paths

## Related

- Follows up on PR #104 (exec auth + initial yamux fixes)
- Companion PR: PipeOpsHQ/pipeops-controller (same branch name)