### PR TITLE
fix: wire up LokiSSL and GrafanaSSL in heartbeat like PrometheusSSL

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1254,6 +1254,9 @@ func (a *Agent) getMonitoringInfo() monitoringInfo {
 	if password, ok := mgr["loki_password"].(string); ok {
 		info.LokiPassword = password
 	}
+	if ssl, ok := mgr["loki_ssl"].(bool); ok {
+		info.LokiSSL = ssl
+	}
 	// Find Loki tunnel port
 	for _, fwd := range tunnelForwards {
 		if fwd.Name == "loki" {
@@ -1271,6 +1274,9 @@ func (a *Agent) getMonitoringInfo() monitoringInfo {
 	}
 	if password, ok := mgr["grafana_password"].(string); ok {
 		info.GrafanaPassword = password
+	}
+	if ssl, ok := mgr["grafana_ssl"].(bool); ok {
+		info.GrafanaSSL = ssl
 	}
 	// Find Grafana tunnel port
 	for _, fwd := range tunnelForwards {
@@ -1635,10 +1641,12 @@ func (a *Agent) sendHeartbeat() error {
 		LokiURL:      monInfo.LokiURL,
 		LokiUsername: monInfo.LokiUsername,
 		LokiPassword: monInfo.LokiPassword,
+		LokiSSL:      monInfo.LokiSSL,
 
 		GrafanaURL:      monInfo.GrafanaURL,
 		GrafanaUsername: monInfo.GrafanaUsername,
 		GrafanaPassword: monInfo.GrafanaPassword,
+		GrafanaSSL:      monInfo.GrafanaSSL,
 
 		// Tunnel ports for monitoring services
 		TunnelPrometheusPort: monInfo.TunnelPrometheusPort,

--- a/internal/components/manager.go
+++ b/internal/components/manager.go
@@ -61,6 +61,7 @@ type LokiConfig struct {
 	RemotePort        int    `yaml:"remote_port"`
 	Username          string `yaml:"username"`
 	Password          string `yaml:"password"`
+	SSL               bool   `yaml:"ssl"`
 	StorageClass      string `yaml:"storage_class"`
 	StorageSize       string `yaml:"storage_size"`
 	EnablePersistence bool   `yaml:"enable_persistence"`
@@ -86,6 +87,7 @@ type GrafanaConfig struct {
 	RemotePort        int    `yaml:"remote_port"`
 	AdminUser         string `yaml:"admin_user"`
 	AdminPassword     string `yaml:"admin_password"`
+	SSL               bool   `yaml:"ssl"`
 	StorageClass      string `yaml:"storage_class"`
 	StorageSize       string `yaml:"storage_size"`
 	EnablePersistence bool   `yaml:"enable_persistence"`
@@ -698,6 +700,7 @@ func (m *Manager) GetMonitoringInfo() map[string]interface{} {
 		info["loki_port"] = m.stack.Loki.LocalPort
 		info["loki_username"] = m.stack.Loki.Username
 		info["loki_password"] = m.stack.Loki.Password
+		info["loki_ssl"] = m.stack.Loki.SSL
 	}
 
 	if m.stack.Grafana != nil && m.stack.Grafana.Enabled {
@@ -711,6 +714,7 @@ func (m *Manager) GetMonitoringInfo() map[string]interface{} {
 		info["grafana_port"] = m.stack.Grafana.LocalPort
 		info["grafana_username"] = m.stack.Grafana.AdminUser
 		info["grafana_password"] = m.stack.Grafana.AdminPassword
+		info["grafana_ssl"] = m.stack.Grafana.SSL
 	}
 
 	return info

--- a/internal/controlplane/types.go
+++ b/internal/controlplane/types.go
@@ -79,6 +79,7 @@ type HeartbeatRequest struct {
 	LokiURL      string `json:"loki_url,omitempty"`
 	LokiUsername string `json:"loki_username,omitempty"`
 	LokiPassword string `json:"loki_password,omitempty"`
+	LokiSSL      bool   `json:"loki_ssl,omitempty"`
 
 	OpenCostBaseURL  string `json:"opencost_base_url,omitempty"`
 	OpenCostUsername string `json:"opencost_username,omitempty"`
@@ -87,6 +88,7 @@ type HeartbeatRequest struct {
 	GrafanaURL      string `json:"grafana_url,omitempty"`
 	GrafanaUsername string `json:"grafana_username,omitempty"`
 	GrafanaPassword string `json:"grafana_password,omitempty"`
+	GrafanaSSL      bool   `json:"grafana_ssl,omitempty"`
 
 	// Tunnel ports for monitoring services
 	TunnelPrometheusPort int `json:"tunnel_prometheus_port,omitempty"`

--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -606,12 +606,14 @@ func (c *WebSocketClient) SendHeartbeat(ctx context.Context, heartbeat *Heartbea
 		msg.Payload["loki_url"] = heartbeat.LokiURL
 		msg.Payload["loki_username"] = heartbeat.LokiUsername
 		msg.Payload["loki_password"] = heartbeat.LokiPassword
+		msg.Payload["loki_ssl"] = heartbeat.LokiSSL
 	}
 
 	if heartbeat.GrafanaURL != "" {
 		msg.Payload["grafana_url"] = heartbeat.GrafanaURL
 		msg.Payload["grafana_username"] = heartbeat.GrafanaUsername
 		msg.Payload["grafana_password"] = heartbeat.GrafanaPassword
+		msg.Payload["grafana_ssl"] = heartbeat.GrafanaSSL
 	}
 
 	if heartbeat.OpenCostBaseURL != "" {


### PR DESCRIPTION
LokiSSL and GrafanaSSL fields existed in the types but were never populated from the components manager, never extracted in getMonitoringInfo, never included in HeartbeatRequest, and never serialized in the WebSocket heartbeat payload. This wires them through the full chain symmetrically with PrometheusSSL:

- Add SSL field to LokiConfig and GrafanaConfig structs
- Emit loki_ssl and grafana_ssl from GetMonitoringInfo()
- Extract loki_ssl and grafana_ssl in getMonitoringInfo()
- Add LokiSSL and GrafanaSSL to HeartbeatRequest struct
- Serialize loki_ssl and grafana_ssl in heartbeat WS payload
- Populate LokiSSL and GrafanaSSL when building heartbeat