### PR TITLE
fix: add get verb to pods/exec RBAC rule for exec WebSocket handshake

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -325,7 +325,7 @@ var requiredRBACRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
 		Resources: []string{"pods/exec", "pods/portforward"},
-		Verbs:     []string{"create"},
+		Verbs:     []string{"create", "get"},
 	},
 	{
 		APIGroups: []string{""},

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -279,9 +279,9 @@ func TestHasRule(t *testing.T) {
 		{
 			name: "exact match",
 			existing: []rbacv1.PolicyRule{
-				{APIGroups: []string{""}, Resources: []string{"pods/exec", "pods/portforward"}, Verbs: []string{"create"}},
+				{APIGroups: []string{""}, Resources: []string{"pods/exec", "pods/portforward"}, Verbs: []string{"create", "get"}},
 			},
-			required: rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"pods/exec", "pods/portforward"}, Verbs: []string{"create"}},
+			required: rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"pods/exec", "pods/portforward"}, Verbs: []string{"create", "get"}},
 			want:     true,
 		},
 		{
@@ -325,10 +325,10 @@ func TestHasRule(t *testing.T) {
 		{
 			name: "covered across multiple rules does not match - each rule must cover independently",
 			existing: []rbacv1.PolicyRule{
-				{APIGroups: []string{""}, Resources: []string{"pods/exec"}, Verbs: []string{"create"}},
-				{APIGroups: []string{""}, Resources: []string{"pods/portforward"}, Verbs: []string{"create"}},
+				{APIGroups: []string{""}, Resources: []string{"pods/exec"}, Verbs: []string{"create", "get"}},
+				{APIGroups: []string{""}, Resources: []string{"pods/portforward"}, Verbs: []string{"create", "get"}},
 			},
-			required: rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"pods/exec", "pods/portforward"}, Verbs: []string{"create"}},
+			required: rbacv1.PolicyRule{APIGroups: []string{""}, Resources: []string{"pods/exec", "pods/portforward"}, Verbs: []string{"create", "get"}},
 			want:     false, // no single rule covers both resources
 		},
 	}


### PR DESCRIPTION
## Summary

- Add `get` verb to the `pods/exec` and `pods/portforward` RBAC rule in the agent's ClusterRole self-reconciliation
- The K8s exec WebSocket upgrade requires `get` on `pods/exec` in addition to `create` — without it, the API server returns 403 Forbidden
- Update tests to reflect the new required verbs

## Root Cause

The agent's RBAC self-reconciliation (`requiredRBACRules` in `pkg/k8s/client.go`) only added `create` for `pods/exec` and `pods/portforward`. The K8s API server requires `get` on the subresource for the initial WebSocket upgrade handshake before `create` is used for the actual exec session.

Error observed:
```
pods "nimble-cause-beta-5f8b5ff5fc-vpv5f" is forbidden: User "system:serviceaccount:pipeops-system:pipeops-agent" cannot get resource "pods/exec" in API group "" in the namespace "beta"
```

## Changes

- `pkg/k8s/client.go`: Changed `Verbs: []string{"create"}` to `Verbs: []string{"create", "get"}` for the pods/exec + pods/portforward rule
- `pkg/k8s/client_test.go`: Updated test cases to match new required verbs

## Testing

All tests pass: `go test ./...` — 16/16 packages pass