### PR TITLE
fix: remove exec debug logging from websocket proxy

### DIFF
--- a/internal/controlplane/websocket_proxy.go
+++ b/internal/controlplane/websocket_proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"net/url"
 	"strings"
 	"sync"
@@ -100,18 +99,11 @@ func (m *WebSocketProxyManager) HandleWebSocketProxyStart(msg *WebSocketMessage)
 		}
 	}
 
-	// Log header keys (not values) for debugging auth flow
-	headerKeys := make([]string, 0, len(headers))
-	for k := range headers {
-		headerKeys = append(headerKeys, k)
-	}
-
 	m.logger.WithFields(logrus.Fields{
-		"stream_id":   streamID,
-		"method":      method,
-		"path":        path,
-		"protocol":    protocol,
-		"header_keys": headerKeys,
+		"stream_id": streamID,
+		"method":    method,
+		"path":      path,
+		"protocol":  protocol,
 	}).Info("WebSocket proxy start requested")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -190,10 +182,6 @@ func (m *WebSocketProxyManager) connectToKubernetes(stream *WebSocketStream, met
 	// Determine Kubernetes API host/TLS/auth from in-cluster config when available.
 	host := m.client.getK8sAPIHost()
 	tlsConfig := m.client.tlsConfig
-	gatewayInjectedAuth := false
-	if authVals, hasAuth := headers["Authorization"]; hasAuth && len(authVals) > 0 && authVals[0] != "" {
-		gatewayInjectedAuth = true
-	}
 	if cfg, err := rest.InClusterConfig(); err == nil {
 		if u, parseErr := url.Parse(cfg.Host); parseErr == nil && u.Host != "" {
 			host = u.Host
@@ -212,23 +200,9 @@ func (m *WebSocketProxyManager) connectToKubernetes(stream *WebSocketStream, met
 			}
 			if _, hasAuth := headers["Authorization"]; !hasAuth {
 				headers["Authorization"] = []string{fmt.Sprintf("Bearer %s", strings.TrimSpace(cfg.BearerToken))}
-				stream.logger.WithField("token_preview", truncateToken(cfg.BearerToken)).
-					Warn("No Authorization from gateway; falling back to in-cluster SA token")
+				stream.logger.Warn("No Authorization from gateway; falling back to in-cluster SA token")
 			}
 		}
-	}
-	// Log which auth source is being used
-	authSource := "gateway-injected"
-	if !gatewayInjectedAuth {
-		authSource = "in-cluster-sa-fallback"
-	}
-	if authVals, ok := headers["Authorization"]; ok && len(authVals) > 0 {
-		stream.logger.WithFields(logrus.Fields{
-			"auth_source":   authSource,
-			"token_preview": truncateToken(authVals[0]),
-		}).Info("K8s WebSocket auth resolved")
-	} else {
-		stream.logger.Warn("No Authorization header set for K8s WebSocket dial — expect 401/403")
 	}
 
 	// Sanitize path and query to prevent injection attacks
@@ -296,13 +270,6 @@ func (m *WebSocketProxyManager) connectToKubernetes(stream *WebSocketStream, met
 		errMsg := fmt.Sprintf("failed to connect to K8s API: %v", err)
 		if resp != nil {
 			errMsg = fmt.Sprintf("%s (status: %d)", errMsg, resp.StatusCode)
-			// Read response body for detailed K8s error message (e.g., RBAC denial reason)
-			if resp.Body != nil {
-				defer resp.Body.Close()
-				if body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024)); readErr == nil && len(body) > 0 {
-					stream.logger.WithField("response_body", string(body)).Error("K8s API rejection details")
-				}
-			}
 		}
 		stream.logger.WithField("detail", errMsg).WithError(err).Error("Failed to connect to Kubernetes API")
 		m.sendWebSocketError(stream.streamID, errMsg)
@@ -595,15 +562,4 @@ func extractWebSocketSubprotocols(headers map[string][]string, explicitProtocol 
 	}
 
 	return protocols
-}
-
-// truncateToken returns a safe preview of a bearer token for logging.
-// Shows the first 10 and last 6 characters with the middle redacted.
-func truncateToken(token string) string {
-	// Strip "Bearer " prefix if present
-	t := strings.TrimPrefix(token, "Bearer ")
-	if len(t) <= 20 {
-		return "[REDACTED-SHORT]"
-	}
-	return t[:10] + "..." + t[len(t)-6:]
 }


### PR DESCRIPTION
## Summary

- Remove all temporary debug/diagnostic logging added during the exec 403 RBAC investigation
- Remove `truncateToken()` helper that logged partial bearer tokens (security concern)
- Remove response body capture on WebSocket dial failure
- Remove header keys logging, auth source tracking, and token preview fields
- Keep the operational `Warn` for SA token fallback (without token preview)

## What was removed

| Block | Description | Why |
|-------|-------------|-----|
| `headerKeys` construction + log field | Logged all header key names on every exec request | Temporary debug, noisy |
| `gatewayInjectedAuth` variable | Tracked whether gateway injected auth | Only fed debug logging |
| `token_preview` on SA fallback | Logged partial bearer token on fallback | Security concern |
| Auth source + token preview Info log | Logged auth source and partial token on every exec | Temporary debug, security concern |
| Response body capture on 403 | `io.ReadAll` of K8s API error body | Added for RBAC diagnosis, now fixed |
| `truncateToken()` function | Helper to show first 10 + last 6 chars of tokens | Dead code, security concern |
| `"io"` import | Only used by response body capture | Dead import |

## What was kept

- `Warn("No Authorization from gateway; falling back to in-cluster SA token")` — useful operational signal without token preview
- All standard operational logging (stream start, connect, close, duration, errors)

## Context

The exec 403 issue was caused by missing `get` verb on `pods/exec` in the agent's ClusterRole RBAC rule, fixed in PR #110. This debug logging was added across commits `6b7898d`, `487dd34`, `03c89fd` to diagnose that specific issue and is no longer needed.

## Testing

All tests pass: `go test ./...` — 16/16 packages pass