### PR TITLE
fix: start ingress watcher immediately after Traefik is ready

### DIFF
--- a/internal/components/manager.go
+++ b/internal/components/manager.go
@@ -118,6 +118,12 @@ type Manager struct {
 	componentInstaller *ComponentInstaller
 	ingressEnabled     bool
 	prometheusCache    *prometheusCacheEntry
+
+	// OnIngressControllerReady is called (in a goroutine) immediately after the
+	// ingress-controller step completes and its pods are ready.  This allows the
+	// agent to start the ingress watcher / gateway proxy without waiting for the
+	// rest of the monitoring stack (cert-manager, prometheus, loki).
+	OnIngressControllerReady func()
 }
 
 // NewManager creates a new monitoring stack manager

--- a/internal/components/orchestrator_test.go
+++ b/internal/components/orchestrator_test.go
@@ -1,0 +1,162 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pipeops/pipeops-vm-agent/pkg/types"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestManager creates a minimal Manager suitable for orchestrator unit tests.
+// It only sets the logger and context — no Helm or K8s dependencies.
+func newTestManager() *Manager {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Manager{
+		logger: logger,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func TestExecuteInstallationPlan_CallbackFiresAfterIngressController(t *testing.T) {
+	mgr := newTestManager()
+	defer mgr.cancel()
+
+	var callbackFired atomic.Bool
+
+	mgr.OnIngressControllerReady = func() {
+		callbackFired.Store(true)
+	}
+
+	steps := []InstallStep{
+		{
+			Name:        "ingress-controller",
+			InstallFunc: func() error { return nil },
+			// Empty ReleaseName triggers a short static sleep in waitForComponentReady
+		},
+		{
+			Name:        "cert-manager",
+			InstallFunc: func() error { return nil },
+		},
+	}
+
+	err := mgr.executeInstallationPlan(types.ProfileHigh, steps)
+	require.NoError(t, err)
+
+	// The callback is invoked in a goroutine; give it a moment to land.
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, callbackFired.Load(), "OnIngressControllerReady callback should have fired after ingress-controller step")
+}
+
+func TestExecuteInstallationPlan_CallbackNotFiredForOtherSteps(t *testing.T) {
+	mgr := newTestManager()
+	defer mgr.cancel()
+
+	var callbackFired atomic.Bool
+
+	mgr.OnIngressControllerReady = func() {
+		callbackFired.Store(true)
+	}
+
+	steps := []InstallStep{
+		{
+			Name:        "cert-manager",
+			InstallFunc: func() error { return nil },
+		},
+		{
+			Name:        "prometheus",
+			InstallFunc: func() error { return nil },
+		},
+	}
+
+	err := mgr.executeInstallationPlan(types.ProfileHigh, steps)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, callbackFired.Load(), "OnIngressControllerReady callback should NOT fire for non-ingress-controller steps")
+}
+
+func TestExecuteInstallationPlan_NoCallbackWhenNil(t *testing.T) {
+	mgr := newTestManager()
+	defer mgr.cancel()
+
+	// OnIngressControllerReady is nil by default — should not panic.
+	steps := []InstallStep{
+		{
+			Name:        "ingress-controller",
+			InstallFunc: func() error { return nil },
+		},
+	}
+
+	err := mgr.executeInstallationPlan(types.ProfileHigh, steps)
+	require.NoError(t, err)
+}
+
+func TestExecuteInstallationPlan_CallbackNotFiredOnIngressControllerFailure(t *testing.T) {
+	mgr := newTestManager()
+	defer mgr.cancel()
+
+	var callbackFired atomic.Bool
+
+	mgr.OnIngressControllerReady = func() {
+		callbackFired.Store(true)
+	}
+
+	steps := []InstallStep{
+		{
+			Name:        "ingress-controller",
+			Critical:    true,
+			InstallFunc: func() error { return fmt.Errorf("traefik install failed") },
+		},
+		{
+			Name:        "cert-manager",
+			InstallFunc: func() error { return nil },
+		},
+	}
+
+	err := mgr.executeInstallationPlan(types.ProfileHigh, steps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ingress-controller")
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, callbackFired.Load(), "OnIngressControllerReady callback should NOT fire when ingress-controller install fails")
+}
+
+func TestExecuteInstallationPlan_CallbackNotFiredOnNonCriticalIngressFailure(t *testing.T) {
+	mgr := newTestManager()
+	defer mgr.cancel()
+
+	var callbackFired atomic.Bool
+
+	mgr.OnIngressControllerReady = func() {
+		callbackFired.Store(true)
+	}
+
+	// Even if ingress-controller is non-critical and fails, the callback should
+	// not fire because the install didn't succeed.
+	steps := []InstallStep{
+		{
+			Name:        "ingress-controller",
+			Critical:    false,
+			InstallFunc: func() error { return fmt.Errorf("traefik install failed") },
+		},
+		{
+			Name:        "cert-manager",
+			InstallFunc: func() error { return nil },
+		},
+	}
+
+	err := mgr.executeInstallationPlan(types.ProfileHigh, steps)
+	require.NoError(t, err) // non-critical failure doesn't abort
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, callbackFired.Load(), "OnIngressControllerReady callback should NOT fire when ingress-controller install fails (even non-critical)")
+}


### PR DESCRIPTION
## Summary

- Fixes 404s on new deployments by starting the ingress watcher / gateway proxy as soon as Traefik (ingress controller) is ready, instead of waiting 20-40 minutes for the full monitoring stack (cert-manager, Prometheus, Loki) to finish installing.
- Adds an `OnIngressControllerReady` callback to `components.Manager` that fires right after the ingress-controller step completes in the installation plan.
- Uses `sync.Once` to guarantee `initializeGatewayProxy()` runs exactly once regardless of whether the callback or the existing `Start()` fallback triggers first.

## Problem

After deploying a project, external URLs return 404 for 20-40 minutes:

```
Start()
  ├── register()
  │     ├── setupMonitoring()            ← BLOCKS for 20-40 min
  │     │     ├── Traefik install        ← ~2 min (ingresses can be created after this)
  │     │     ├── cert-manager           ← 5-10 min
  │     │     ├── Prometheus             ← 5-10 min
  │     │     └── Loki                   ← 5-10 min
  │     └── waitForMonitoring()
  └── initializeGatewayProxy()           ← IngressWatcher starts HERE, 20-40 min late
```

Ingresses exist in K8s right after Traefik is ready, but routes aren't registered with the gateway until `initializeGatewayProxy()` runs after the entire stack completes.

## Solution

```
setupMonitoring()
  ├── Traefik install                    ← ~2 min
  ├── waitForComponentReady()
  ├── OnIngressControllerReady callback  ← IngressWatcher starts HERE (~T+2min)
  ├── cert-manager                       ← continues in background
  ├── Prometheus
  └── Loki
```

## Changes

| File | Change |
|------|--------|
| `internal/components/manager.go` | Added `OnIngressControllerReady func()` field to `Manager` struct |
| `internal/components/orchestrator.go` | Fire callback in goroutine after `"ingress-controller"` step succeeds |
| `internal/agent/agent.go` | Wire callback in `setupMonitoring()`, add `sync.Once` guard to both trigger paths |
| `internal/components/orchestrator_test.go` | 5 tests: callback fires, skips non-ingress steps, nil-safe, skips on failure |

## Testing

- All existing tests pass with `-race` flag
- 5 new orchestrator tests cover callback behavior
- `go vet` and `go fmt` clean