### PR TITLE
fix: enable Traefik allowCrossNamespace for cross-namespace IngressRoute references

### DIFF
--- a/internal/ingress/traefik.go
+++ b/internal/ingress/traefik.go
@@ -141,7 +141,8 @@ func (tc *TraefikController) buildBaseValues(profile types.ResourceProfile) map[
 		},
 		"providers": map[string]interface{}{
 			"kubernetesCRD": map[string]interface{}{
-				"enabled": true,
+				"enabled":             true,
+				"allowCrossNamespace": true,
 			},
 			"kubernetesIngress": map[string]interface{}{
 				"enabled": true,


### PR DESCRIPTION
## Summary

- Enables `providers.kubernetesCRD.allowCrossNamespace: true` in Traefik Helm values so that IngressRoute resources can reference services in other namespaces
- Without this setting, Traefik silently ignores cross-namespace service references in IngressRoute CRDs, which can cause routing failures for deployments that need to reference services across namespaces (e.g., middleware in a shared namespace)

## Changes

- `internal/ingress/traefik.go`: Added `allowCrossNamespace: true` to the `kubernetesCRD` provider configuration in `buildBaseValues()`