### PR TITLE
fix: prioritize end-to-end readiness by async monitoring bootstrap

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -507,13 +507,9 @@ func (a *Agent) Start() error {
 		return fmt.Errorf("failed to register agent with control plane: %w", err)
 	}
 
-	// Configure monitoring tunnels if monitoring is ready
-	if a.monitoringMgr != nil && a.monitoringReady && a.tunnelMgr != nil {
-		a.logger.Info("Adding monitoring service tunnels...")
-		if err := a.addMonitoringTunnels(); err != nil {
-			a.logger.WithError(err).Warn("Failed to add monitoring tunnels (non-fatal)")
-		}
-	}
+	// Bootstrap monitoring/gateway setup asynchronously so deployment traffic can
+	// flow as soon as registration completes.
+	a.startMonitoringBootstrap()
 
 	// Start tunnel manager (if initialized) - only after successful registration
 	if a.tunnelMgr != nil {
@@ -675,8 +671,9 @@ func (a *Agent) Stop() error {
 	return nil
 }
 
-// register registers the agent with the control plane via HTTP
-// This includes setting up the monitoring stack and waiting for it to be ready
+// register registers the agent with the control plane via HTTP.
+// Monitoring/bootstrap work runs asynchronously from Start() so registration
+// can complete quickly and end-to-end deployment traffic can flow sooner.
 func (a *Agent) register() error {
 	a.registerMutex.Lock()
 	defer a.registerMutex.Unlock()
@@ -932,30 +929,36 @@ func (a *Agent) register() error {
 
 	a.updateConnectionState(StateConnected)
 
-	// Set up monitoring stack AFTER successful registration (only if not already set up)
-	if err := a.setupMonitoring(); err != nil {
-		return fmt.Errorf("failed to set up monitoring stack: %w", err)
-	}
-
-	// Wait for monitoring to be ready (with timeout)
-	a.monitoringMutex.RLock()
-	alreadyReady := a.monitoringReady
-	a.monitoringMutex.RUnlock()
-
-	if !alreadyReady {
-		if err := a.waitForMonitoring(120 * time.Second); err != nil {
-			return fmt.Errorf("monitoring stack not ready within timeout: %w", err)
-		}
-		a.logger.Info("✓ Monitoring stack ready and operational")
-	}
-
-	// Optionally install the env-aware gateway after monitoring setup
-	if err := a.setupGateway(); err != nil {
-		// Non-fatal: gateway is optional
-		a.logger.WithError(err).Warn("Failed to set up gateway (optional)")
-	}
-
 	return nil
+}
+
+// startMonitoringBootstrap installs monitoring components in the background so
+// agent registration and ingress sync are not blocked on heavy Helm workflows.
+func (a *Agent) startMonitoringBootstrap() {
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+
+		if err := a.setupMonitoring(); err != nil {
+			a.logger.WithError(err).Warn("Failed to set up monitoring stack in background")
+			return
+		}
+
+		a.logger.Info("✓ Monitoring stack ready and operational")
+
+		if a.tunnelMgr != nil && a.monitoringMgr != nil {
+			a.logger.Info("Adding monitoring service tunnels...")
+			if err := a.addMonitoringTunnels(); err != nil {
+				a.logger.WithError(err).Warn("Failed to add monitoring tunnels (non-fatal)")
+			}
+		}
+
+		// Optionally install the env-aware gateway after monitoring setup.
+		if err := a.setupGateway(); err != nil {
+			// Non-fatal: gateway is optional
+			a.logger.WithError(err).Warn("Failed to set up gateway (optional)")
+		}
+	}()
 }
 
 // setupMonitoring initializes and starts the monitoring stack

--- a/internal/components/manager.go
+++ b/internal/components/manager.go
@@ -677,26 +677,20 @@ func (m *Manager) GetMonitoringInfo() map[string]interface{} {
 		}
 
 		if !found {
-			// Fall back to expected kube-prometheus-stack naming
-			serviceName = fmt.Sprintf("%s-prometheus", m.stack.Prometheus.ReleaseName)
-			port = int32(m.stack.Prometheus.LocalPort)
 			if m.prometheusCache == nil || time.Since(m.prometheusCache.timestamp) > 5*time.Minute {
-				m.logger.WithFields(logrus.Fields{
-					"serviceName": serviceName,
-					"namespace":   m.stack.Prometheus.Namespace,
-				}).Warn("Using default Prometheus service name (discovery failed)")
+				m.logger.WithField("namespace", m.stack.Prometheus.Namespace).Info("Prometheus service not discovered yet; skipping URL advertisement")
 			}
+		} else {
+			info["prometheus_url"] = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
+				serviceName, m.stack.Prometheus.Namespace, port)
+			// Also provide structured data for Kubernetes API proxy construction
+			info["prometheus_service_name"] = serviceName
+			info["prometheus_namespace"] = m.stack.Prometheus.Namespace
+			info["prometheus_port"] = port
+			info["prometheus_username"] = m.stack.Prometheus.Username
+			info["prometheus_password"] = m.stack.Prometheus.Password
+			info["prometheus_ssl"] = m.stack.Prometheus.SSL
 		}
-
-		info["prometheus_url"] = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
-			serviceName, m.stack.Prometheus.Namespace, port)
-		// Also provide structured data for Kubernetes API proxy construction
-		info["prometheus_service_name"] = serviceName
-		info["prometheus_namespace"] = m.stack.Prometheus.Namespace
-		info["prometheus_port"] = port
-		info["prometheus_username"] = m.stack.Prometheus.Username
-		info["prometheus_password"] = m.stack.Prometheus.Password
-		info["prometheus_ssl"] = m.stack.Prometheus.SSL
 	}
 
 	if m.stack.Loki != nil && m.stack.Loki.Enabled {
@@ -1113,6 +1107,9 @@ func (m *Manager) waitForCertManagerWebhook() error {
 // createDefaultClusterIssuers creates default Let's Encrypt ClusterIssuers
 func (m *Manager) createDefaultClusterIssuers() error {
 	m.logger.Info("Creating default Let's Encrypt ClusterIssuers...")
+	created := 0
+	forbidden := 0
+	failed := 0
 
 	// ClusterIssuer for Let's Encrypt production (letsencrypt-prod)
 	prodIssuer := `apiVersion: cert-manager.io/v1
@@ -1150,16 +1147,48 @@ spec:
 
 	// Apply letsencrypt-prod ClusterIssuer
 	if err := m.applyClusterIssuer(prodIssuer); err != nil {
-		m.logger.WithError(err).Warn("Failed to create letsencrypt-prod ClusterIssuer")
+		if apierrors.IsForbidden(err) {
+			forbidden++
+			m.logger.WithError(err).Warn("Skipping letsencrypt-prod ClusterIssuer creation due to RBAC")
+		} else {
+			failed++
+			m.logger.WithError(err).Warn("Failed to create letsencrypt-prod ClusterIssuer")
+		}
 	} else {
+		created++
 		m.logger.Info("✓ Created ClusterIssuer: letsencrypt-prod")
 	}
 
 	// Apply letsencrypt-production ClusterIssuer
 	if err := m.applyClusterIssuer(prodProductionIssuer); err != nil {
-		m.logger.WithError(err).Warn("Failed to create letsencrypt-production ClusterIssuer")
+		if apierrors.IsForbidden(err) {
+			forbidden++
+			m.logger.WithError(err).Warn("Skipping letsencrypt-production ClusterIssuer creation due to RBAC")
+		} else {
+			failed++
+			m.logger.WithError(err).Warn("Failed to create letsencrypt-production ClusterIssuer")
+		}
 	} else {
+		created++
 		m.logger.Info("✓ Created ClusterIssuer: letsencrypt-production")
+	}
+
+	if created == 0 && forbidden > 0 && failed == 0 {
+		m.logger.WithField("forbidden", forbidden).Warn("Skipping default ClusterIssuer creation due to missing cluster-scoped RBAC")
+		return nil
+	}
+
+	if failed > 0 && created == 0 {
+		return fmt.Errorf("failed to create default ClusterIssuers (failed=%d, forbidden=%d)", failed, forbidden)
+	}
+
+	if failed > 0 || forbidden > 0 {
+		m.logger.WithFields(logrus.Fields{
+			"created":   created,
+			"forbidden": forbidden,
+			"failed":    failed,
+		}).Warn("Default ClusterIssuer creation partially completed")
+		return nil
 	}
 
 	m.logger.Info("✓ Default ClusterIssuers created - automatic TLS enabled for ingresses")

--- a/internal/components/orchestrator.go
+++ b/internal/components/orchestrator.go
@@ -57,10 +57,6 @@ func (m *Manager) executeInstallationPlan(profile types.ResourceProfile, steps [
 			continue
 		}
 
-		// Stability Gate: Wait for the component to settle before proceeding
-		// This prevents resource spikes from overlapping startups
-		m.waitForComponentReady(step.Namespace, step.ReleaseName, profile)
-
 		// Fire the early-ready callback as soon as the ingress controller is up.
 		// This lets the agent start the ingress watcher / gateway proxy immediately
 		// instead of waiting for the rest of the monitoring stack.
@@ -68,6 +64,11 @@ func (m *Manager) executeInstallationPlan(profile types.ResourceProfile, steps [
 			m.logger.Info("Ingress controller ready — invoking early-ready callback")
 			go m.OnIngressControllerReady()
 		}
+
+		// Stability Gate: Wait for the component to settle before proceeding.
+		// The ingress callback above runs before this wait to prioritize end-to-end
+		// deployment readiness while remaining serialized for subsequent steps.
+		m.waitForComponentReady(step.Namespace, step.ReleaseName, profile)
 	}
 
 	if len(failedComponents) > 0 {
@@ -88,7 +89,7 @@ func (m *Manager) waitForComponentReady(namespace, releaseName string, profile t
 		// Just a static sleep for non-Helm components based on profile
 		sleepTime := 10 * time.Second
 		if profile == types.ProfileLow {
-			sleepTime = 30 * time.Second
+			sleepTime = 8 * time.Second
 		}
 		m.logger.WithField("duration", sleepTime).Info("Waiting for static stabilization...")
 		time.Sleep(sleepTime)
@@ -107,7 +108,7 @@ func (m *Manager) waitForComponentReady(namespace, releaseName string, profile t
 
 	timeout := 5 * time.Minute
 	if profile == types.ProfileLow {
-		timeout = 10 * time.Minute // Give low resource nodes more time
+		timeout = 4 * time.Minute
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -152,7 +153,7 @@ func (m *Manager) waitForComponentReady(namespace, releaseName string, profile t
 				// Cool-down period after ready state to allow CPU to drop
 				coolDown := 5 * time.Second
 				if profile == types.ProfileLow {
-					coolDown = 30 * time.Second // Significant cool-down for low resource nodes
+					coolDown = 8 * time.Second
 				}
 				m.logger.WithField("duration", coolDown).Info("Cooling down before next step...")
 				time.Sleep(coolDown)


### PR DESCRIPTION
## Summary
- move monitoring setup out of the registration critical path so the agent starts serving traffic immediately after registration
- run monitoring + optional gateway install in the background, and add monitoring tunnels only when monitoring manager is available
- speed up low-profile orchestration by reducing readiness timeout/cooldown waits and fire ingress early-ready callback before post-install stabilization wait
- avoid advertising Prometheus endpoints before service discovery succeeds, and make ClusterIssuer logs accurately report RBAC-forbidden/partial outcomes

## Validation
- go test ./internal/agent/...
- go test ./internal/components/...