### PR TITLE
fix: provide default Helm args for agent startup

### DIFF
--- a/helm/pipeops-agent/templates/deployment.yaml
+++ b/helm/pipeops-agent/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.agent.args }}
+          args:
+            {{- toYaml .Values.agent.args | nindent 12 }}
+          {{- end }}
           env:
             - name: PIPEOPS_API_URL
               value: {{ .Values.agent.pipeops.apiUrl | quote }}

--- a/helm/pipeops-agent/values.yaml
+++ b/helm/pipeops-agent/values.yaml
@@ -74,6 +74,9 @@ agent:
   # Agent configuration
   id: ""  # Optional: Set specific agent ID (auto-generated if not specified)
   name: "pipeops-agent"
+  args:
+    - "--config=/etc/pipeops/config.yaml"
+    - "--in-cluster=true"
   
   # Cluster configuration
   cluster:


### PR DESCRIPTION
## Summary
- add default container args in Helm values so the agent starts with the required in-cluster flags
- wire `agent.args` into the Deployment template so users can override startup arguments when needed
- set chart defaults to `--config=/etc/pipeops/config.yaml` and `--in-cluster=true` to prevent help-text exits and CrashLoopBackOff

## Validation
- helm template pipeops-agent ./helm/pipeops-agent