### PR TITLE
fix: add Helm ownership metadata to namespace

### DIFF
--- a/helm/pipeops-agent/templates/namespace.yaml
+++ b/helm/pipeops-agent/templates/namespace.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Release.Namespace }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     name: {{ .Release.Namespace }}
     app.kubernetes.io/name: {{ include "pipeops-agent.name" . }}


### PR DESCRIPTION
## Summary
- add Helm ownership annotations to the chart-managed Namespace resource
- include `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` on `helm/pipeops-agent/templates/namespace.yaml`
- this lets Helm adopt/manage an existing namespace instead of failing with ownership conflicts

## Validation
- helm template pipeops-agent ./helm/pipeops-agent