### PR TITLE
fix: improve control plane reconnect resilience and self-healing

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1499,10 +1499,16 @@ func (a *Agent) handleHeartbeatFailure() {
 	a.metrics.recordHeartbeatFailure()
 
 	if failures >= threshold {
-		a.logger.WithFields(logrus.Fields{
+		fields := logrus.Fields{
 			"consecutive_failures": failures,
 			"threshold":            threshold,
-		}).Warn("Heartbeat failure threshold reached, marking disconnected")
+		}
+		if a.controlPlane != nil {
+			if d := a.controlPlane.DisconnectedDuration(); d > 0 {
+				fields["disconnected_for"] = d.Round(time.Second)
+			}
+		}
+		a.logger.WithFields(fields).Warn("Heartbeat failure threshold reached, marking disconnected")
 		a.updateConnectionState(StateDisconnected)
 	} else {
 		a.logger.WithFields(logrus.Fields{
@@ -2003,10 +2009,14 @@ func (a *Agent) handleControlPlaneReconnect() {
 	if a.controlPlane.IsGatewayMode() {
 		a.logger.Info("Gateway connection restored - session resumed automatically")
 
-		// Send a heartbeat immediately to ensure Gateway has fresh status
+		// Send a heartbeat immediately to ensure Gateway has fresh status.
+		// If the heartbeat fails the connection is not truly healthy, so signal
+		// the WebSocket client to start another reconnect attempt right away
+		// instead of waiting for the next ping/pong failure.
 		go func() {
 			if err := a.sendHeartbeat(); err != nil {
-				a.logger.WithError(err).Warn("Failed to send heartbeat after gateway reconnect")
+				a.logger.WithError(err).Warn("Failed to send heartbeat after gateway reconnect — triggering immediate reconnect")
+				a.controlPlane.TriggerReconnectNow()
 			}
 		}()
 

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -516,3 +516,21 @@ func (c *Client) IsGatewayMode() bool {
 	}
 	return c.wsClient.IsGatewayMode()
 }
+
+// TriggerReconnectNow interrupts any current backoff sleep and starts an
+// immediate reconnect attempt. Safe to call when not reconnecting (no-op).
+func (c *Client) TriggerReconnectNow() {
+	if c.wsClient == nil {
+		return
+	}
+	c.wsClient.TriggerReconnectNow()
+}
+
+// DisconnectedDuration returns how long the underlying WebSocket has been
+// disconnected. Returns 0 when connected, -1 if it has never connected.
+func (c *Client) DisconnectedDuration() time.Duration {
+	if c.wsClient == nil {
+		return -1
+	}
+	return c.wsClient.DisconnectedDuration()
+}

--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -103,6 +103,14 @@ type WebSocketClient struct {
 	yamuxClient      *yamuxClientWrapper
 	yamuxClientMutex sync.RWMutex
 	yamuxEnabled     bool // Set to true when gateway negotiates yamux
+
+	// Reconnect signalling: a buffered channel of size 1 lets external callers
+	// interrupt the backoff sleep and trigger an immediate reconnect attempt.
+	reconnectNow chan struct{}
+
+	// Tracks when the WebSocket last transitioned to connected, for observability.
+	lastConnectedAt time.Time
+	lastConnectedMu sync.RWMutex
 }
 
 type proxyResponseSender interface {
@@ -168,6 +176,7 @@ func NewWebSocketClient(apiURL, token, agentID string, timeouts *types.Timeouts,
 		activeRequestBodyPipes: make(map[string]*io.PipeWriter),
 		unknownMessageTypes:    make(map[string]int),
 		connected:              false,
+		reconnectNow:           make(chan struct{}, 1),
 	}
 
 	client.wsProxyManager = NewWebSocketProxyManager(client, logger)
@@ -216,6 +225,7 @@ func NewWebSocketClientWithGateway(gatewayURL, token, agentID, clusterUUID, agen
 		gatewayURL:             gatewayURL,
 		clusterUUID:            clusterUUID,
 		agentVersion:           agentVersion,
+		reconnectNow:           make(chan struct{}, 1),
 	}
 
 	client.wsProxyManager = NewWebSocketProxyManager(client, logger)
@@ -1774,66 +1784,106 @@ func (c *WebSocketClient) pingHandler() {
 	}
 }
 
-// reconnect attempts to reconnect to the WebSocket
+// reconnect is the entry-point for reconnection. It is safe to call concurrently:
+// only the first caller starts the reconnect loop; subsequent calls while the loop
+// is already running are ignored. The loop runs until a connection succeeds, a
+// non-retryable error is detected, or the client context is cancelled.
 func (c *WebSocketClient) reconnect() {
-	// Prevent multiple concurrent reconnection attempts
 	if !c.reconnecting.CompareAndSwap(false, true) {
 		c.logger.Debug("Reconnection already in progress, skipping duplicate attempt")
 		return
 	}
+	go c.reconnectLoop()
+}
+
+// reconnectLoop is the single goroutine that owns the reconnect lifecycle.
+// It uses exponential backoff with jitter and can be interrupted immediately
+// via TriggerReconnectNow() so the agent reacts quickly when the control plane
+// comes back up after an outage.
+func (c *WebSocketClient) reconnectLoop() {
 	defer c.reconnecting.Store(false)
 
-	// Add jitter to prevent thundering herd (±25%)
-	jitter := time.Duration(rand.Float64() * 0.25 * float64(c.reconnectDelay))
-	delay := c.reconnectDelay + jitter
-
-	c.logger.WithFields(logrus.Fields{
-		"base_delay":   c.reconnectDelay,
-		"jitter":       jitter,
-		"total_delay":  delay,
-		"next_delay":   c.reconnectDelay * 2,
-		"gateway_mode": c.gatewayMode,
-	}).Info("Attempting to reconnect to WebSocket")
-
-	// Wait for delay or context cancellation
-	select {
-	case <-c.ctx.Done():
-		c.logger.Debug("Context cancelled during reconnect delay, aborting")
-		return
-	case <-time.After(delay):
+	delay := c.timeouts.WebSocketReconnect
+	if delay <= 0 {
+		delay = 500 * time.Millisecond
+	}
+	maxDelay := c.maxReconnectDelay
+	if maxDelay <= 0 {
+		maxDelay = 60 * time.Second
 	}
 
-	// Check context again before connecting
-	if c.ctx.Err() != nil {
-		c.logger.Debug("Context cancelled, aborting reconnect")
-		return
-	}
+	for attempt := 1; ; attempt++ {
+		jitter := time.Duration(rand.Float64() * 0.25 * float64(delay))
+		wait := delay + jitter
 
-	// Use appropriate connect method based on mode
-	var err error
-	if c.gatewayMode {
-		err = c.ConnectToGateway()
-	} else {
-		err = c.Connect()
-	}
+		c.logger.WithFields(logrus.Fields{
+			"attempt":      attempt,
+			"wait":         wait,
+			"gateway_mode": c.gatewayMode,
+		}).Info("Attempting to reconnect to WebSocket")
 
-	if err != nil {
-		c.logger.WithError(err).Warn("Reconnection failed, will retry")
-
-		// Increase reconnect delay with exponential backoff
-		c.reconnectDelay *= 2
-		if c.reconnectDelay > c.maxReconnectDelay {
-			c.reconnectDelay = c.maxReconnectDelay
+		// Sleep, but allow immediate wake-up if TriggerReconnectNow is called.
+		select {
+		case <-c.ctx.Done():
+			c.logger.Debug("Context cancelled during reconnect delay, aborting")
+			return
+		case <-time.After(wait):
+		case <-c.reconnectNow:
+			c.logger.Debug("Reconnect triggered immediately via signal")
 		}
 
-		// Try again
-		go c.reconnect()
-	} else {
-		c.logger.Info("✓ Reconnected successfully to WebSocket")
-		if c.onReconnect != nil {
-			go c.onReconnect()
+		if c.ctx.Err() != nil {
+			return
+		}
+
+		var err error
+		if c.gatewayMode {
+			err = c.ConnectToGateway()
+		} else {
+			err = c.Connect()
+		}
+
+		if err == nil {
+			c.logger.WithField("attempts", attempt).Info("✓ Reconnected successfully to WebSocket")
+			if c.onReconnect != nil {
+				go c.onReconnect()
+			}
+			return
+		}
+
+		// Auth failures (401/403) will not be resolved by retrying — trigger
+		// re-registration so the agent obtains a valid token/cluster state.
+		if isNonRetryableHTTPError(err) {
+			c.logger.WithError(err).Error("Non-retryable auth error during reconnect, triggering re-registration")
+			if c.onRegistrationError != nil {
+				c.onRegistrationError(err)
+			}
+			return
+		}
+
+		disconnected := c.DisconnectedDuration()
+		c.logger.WithFields(logrus.Fields{
+			"attempt":             attempt,
+			"error":               err,
+			"disconnected_for":    disconnected,
+		}).Warn("Reconnection failed, will retry with backoff")
+
+		// Exponential backoff capped at maxDelay
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
 		}
 	}
+}
+
+// isNonRetryableHTTPError returns true for HTTP errors that cannot be resolved
+// by retrying with the same credentials (e.g. 401 Unauthorised, 403 Forbidden).
+func isNonRetryableHTTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "status 401") || strings.Contains(s, "status 403")
 }
 
 // SendBackpressureSignal sends a backpressure signal to the control plane
@@ -2714,7 +2764,36 @@ func (c *WebSocketClient) IsGatewayMode() bool {
 func (c *WebSocketClient) setConnected(connected bool) {
 	c.connectedMutex.Lock()
 	defer c.connectedMutex.Unlock()
+	if connected && !c.connected {
+		c.lastConnectedMu.Lock()
+		c.lastConnectedAt = time.Now()
+		c.lastConnectedMu.Unlock()
+	}
 	c.connected = connected
+}
+
+// DisconnectedDuration returns how long the client has been disconnected.
+// Returns 0 when currently connected, -1 if it has never successfully connected.
+func (c *WebSocketClient) DisconnectedDuration() time.Duration {
+	if c.isConnected() {
+		return 0
+	}
+	c.lastConnectedMu.RLock()
+	last := c.lastConnectedAt
+	c.lastConnectedMu.RUnlock()
+	if last.IsZero() {
+		return -1
+	}
+	return time.Since(last)
+}
+
+// TriggerReconnectNow interrupts the current backoff sleep and triggers an
+// immediate reconnect attempt. Safe to call when not reconnecting (no-op).
+func (c *WebSocketClient) TriggerReconnectNow() {
+	select {
+	case c.reconnectNow <- struct{}{}:
+	default: // channel already has a pending signal, no need to add another
+	}
 }
 
 func (c *WebSocketClient) SetK8sAPIHost(host string) {

--- a/pkg/types/timeouts.go
+++ b/pkg/types/timeouts.go
@@ -46,7 +46,7 @@ func DefaultTimeouts() *Timeouts {
 		WebSocketPing:         10 * time.Second,       // Increased frequency (was 30s) to keep NAT/LB alive
 		WebSocketRead:         60 * time.Second,       // 2x ping interval
 		WebSocketReconnect:    500 * time.Millisecond, // Fast initial reconnect
-		WebSocketReconnectMax: 15 * time.Second,       // Cap for sustained outages
+		WebSocketReconnectMax: 60 * time.Second,       // Cap for sustained outages (4× increase reduces hammering during extended CP downtime)
 
 		// Kubernetes API timeouts
 		K8sOperation:     30 * time.Second,


### PR DESCRIPTION
## Summary

- **Loop-based reconnect** replaces the recursive goroutine pattern in `WebSocketClient.reconnect()`. A single `reconnectLoop()` goroutine owns the full reconnect lifecycle, eliminating the CAS race window where `reconnecting=false` briefly between goroutines, which could allow duplicate reconnect goroutines to run simultaneously during rapid connection flapping.
- **Interruptible backoff** via a `reconnectNow chan struct{}` field. `TriggerReconnectNow()` sends on this channel, waking the backoff `select` immediately so the agent reconnects within milliseconds of the control plane recovering instead of waiting out the full delay.
- **Non-retryable error detection** — `isNonRetryableHTTPError()` catches `401`/`403` responses. Instead of retrying indefinitely with bad credentials, the reconnect loop stops and calls `onRegistrationError` to trigger re-registration.
- **Max backoff increased 15s → 60s** — reduces unnecessary load on the control plane during extended outages (~60 req/hr vs ~240 req/hr previously).
- **Gateway heartbeat failure wired to immediate reconnect** — after a gateway session is restored, a failed post-reconnect heartbeat now calls `TriggerReconnectNow()` rather than just logging a warning, so a genuinely unhealthy reconnect is retried immediately rather than waiting up to 60s for the next ping/pong timeout.
- **`DisconnectedDuration()`** exposed on both `WebSocketClient` and `Client` — surfaced in heartbeat-threshold logs as `disconnected_for` for better operational visibility.

## Test plan

- [ ] Simulate control plane restart: agent should reconnect within one backoff window after CP comes back up
- [ ] Simulate 401 from gateway after token rotation: agent should call re-registration path, not loop forever
- [ ] Simulate extended CP outage (>5 min): verify reconnect attempts cap at ~60s intervals, not 15s
- [ ] Confirm no goroutine accumulation under rapid connect/disconnect cycles (e.g. using `pprof` goroutine dump)
- [ ] Verify `disconnected_for` appears in logs when heartbeat threshold is crossed

🤖 Generated with [Claude Code](https://claude.com/claude-code)