### PR TITLE
fix: propagate namespace creation errors instead of silently swallowing them

### DIFF
--- a/internal/helm/installer.go
+++ b/internal/helm/installer.go
@@ -590,12 +590,14 @@ func (h *HelmInstaller) createNamespace(ctx context.Context, namespace string) e
 
 	_, err := h.K8sClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
-		// Ignore error if namespace already exists
-		h.logger.WithError(err).Debug("Namespace may already exist")
-		return nil
+		if k8serrors.IsAlreadyExists(err) {
+			h.logger.WithField("namespace", namespace).Debug("Namespace already exists")
+			return nil
+		}
+		return fmt.Errorf("failed to create namespace %q: %w", namespace, err)
 	}
 
-	h.logger.WithField("namespace", namespace).Debug("Created namespace")
+	h.logger.WithField("namespace", namespace).Info("Created namespace")
 	return nil
 }
 


### PR DESCRIPTION
## Root Cause

`HelmInstaller.createNamespace` (`internal/helm/installer.go:584`) was catching **all** errors and returning `nil`, not just `AlreadyExists`:

```go
// Before
if err != nil {
    h.logger.WithError(err).Debug("Namespace may already exist")
    return nil  // silently drops RBAC errors, API timeouts, etc.
}
```

When namespace creation failed (e.g. the agent lacked RBAC to create namespaces, or there was a transient API error), the function reported success. Helm then attempted to install the chart into a namespace that was never actually created, producing:

```
Error: failed to create resource: namespaces "pipeops-monitoring" not found
```

## Fix

Only `AlreadyExists` is silently ignored now. Every other error is propagated so the install step fails fast with a meaningful message instead of blowing up mid-chart-apply.

```go
// After
if k8serrors.IsAlreadyExists(err) {
    return nil
}
return fmt.Errorf("failed to create namespace %q: %w", namespace, err)
```

## Test plan

- [ ] Verify auto-install succeeds when the agent has correct RBAC
- [ ] Verify a clear error is surfaced (not `namespace not found`) when the agent lacks namespace-create permission
- [ ] Confirm `pipeops-monitoring` namespace is present after a clean install before any Helm chart is applied to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)