### PR TITLE
fix: use url.URL struct for service URL to prevent SSRF (CodeQL #39)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2669,18 +2669,43 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 		}).Debug("Added X-Forwarded-Proto: https header for proxied request")
 	}
 
-	// Construct the URL for the in-cluster service.
-	// Use https:// when the controller indicates backend TLS (e.g., ingress-nginx port 443).
+	// Validate path before using it in URL construction.
+	// req.Path comes from the control plane message; it must not contain characters
+	// that can rewrite the URL host (e.g. "@", "://", "..").
+	if err := validatePath(req.Path); err != nil {
+		if body != nil {
+			_ = body.Close()
+		}
+		return 0, nil, nil, fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Construct the URL for the in-cluster service using url.URL so that
+	// user-controlled values (path, query) are always treated as data, never
+	// as URL structure. fmt.Sprintf concatenation allows "@" in the path to
+	// rewrite the host (e.g. "http://svc:80@evil.com/x").
 	serviceHost := buildServiceFQDN(req.ServiceName, req.Namespace)
 	httpScheme := "http"
 	if req.Scheme == "https" {
 		httpScheme = "https"
 	}
-	serviceURL := fmt.Sprintf("%s://%s:%d%s", httpScheme, serviceHost, req.ServicePort, req.Path)
-
-	if req.Query != "" {
-		serviceURL = fmt.Sprintf("%s?%s", serviceURL, req.Query)
+	targetURL := &neturl.URL{
+		Scheme: httpScheme,
+		Host:   fmt.Sprintf("%s:%d", serviceHost, req.ServicePort),
+		Path:   req.Path,
 	}
+	if req.Query != "" {
+		// Parse and re-encode the query so injection attempts become harmless
+		// encoded strings rather than live URL parameters.
+		parsed, err := neturl.ParseQuery(req.Query)
+		if err != nil {
+			if body != nil {
+				_ = body.Close()
+			}
+			return 0, nil, nil, fmt.Errorf("invalid query string: %w", err)
+		}
+		targetURL.RawQuery = parsed.Encode()
+	}
+	serviceURL := targetURL.String()
 
 	logger := a.logger.WithFields(logrus.Fields{
 		"service_url":  serviceURL,
@@ -3537,19 +3562,34 @@ func (a *Agent) handleWebSocketProxy(ctx context.Context, req *controlplane.Prox
 		}
 	}
 
-	// Build WebSocket URL to service.
+	// Validate path before URL construction to block "@"-based host injection.
+	if err := validatePath(req.Path); err != nil {
+		_ = writer.CloseWithError(fmt.Errorf("invalid path: %w", err))
+		return
+	}
+
+	// Build WebSocket URL to service using url.URL so user-controlled values
+	// cannot rewrite the host via URL meta-characters.
 	// Use wss:// when the original request was over HTTPS, otherwise ws://.
-	// In-cluster services typically terminate TLS at ingress, so ws:// is the default.
 	serviceHost := buildServiceFQDN(req.ServiceName, req.Namespace)
 	wsScheme := "ws"
 	if req.Scheme == "https" {
 		wsScheme = "wss"
 	}
-	serviceURL := fmt.Sprintf("%s://%s:%d%s", wsScheme, serviceHost, req.ServicePort, req.Path)
-
-	if req.Query != "" {
-		serviceURL = fmt.Sprintf("%s?%s", serviceURL, req.Query)
+	targetWS := &neturl.URL{
+		Scheme: wsScheme,
+		Host:   fmt.Sprintf("%s:%d", serviceHost, req.ServicePort),
+		Path:   req.Path,
 	}
+	if req.Query != "" {
+		parsed, err := neturl.ParseQuery(req.Query)
+		if err != nil {
+			_ = writer.CloseWithError(fmt.Errorf("invalid query string: %w", err))
+			return
+		}
+		targetWS.RawQuery = parsed.Encode()
+	}
+	serviceURL := targetWS.String()
 
 	logger.WithField("target_url", serviceURL).Debug("Connecting to service WebSocket")
 


### PR DESCRIPTION
## Vulnerability

CodeQL alert [#39](https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/39) — `go/request-forgery` (CWE-918, Critical)

Service URLs were constructed with `fmt.Sprintf`:

```go
// BEFORE — vulnerable
serviceURL := fmt.Sprintf("%s://%s:%d%s", scheme, serviceHost, port, req.Path)
if req.Query != "" {
    serviceURL = fmt.Sprintf("%s?%s", serviceURL, req.Query)
}
```

A `req.Path` value containing `@` rewrites the URL host. For example:

| `req.Path` | Resulting URL | Parsed host |
|---|---|---|
| `@evil.com/x` | `http://svc.ns.svc:80@evil.com/x` | `evil.com` |
| `@10.0.0.1/internal` | `http://svc.ns.svc:80@10.0.0.1/internal` | `10.0.0.1` |

This bypasses the service FQDN restriction entirely — the agent proxies to an attacker-controlled host.

The `req.Query` field was also appended raw, allowing query string injection.

## Fix

Replace both URL constructions (HTTP proxy and WebSocket proxy in `agent.go`) with `url.URL` struct assignment:

```go
// AFTER — safe
if err := validatePath(req.Path); err != nil { ... }

targetURL := &neturl.URL{
    Scheme: scheme,
    Host:   fmt.Sprintf("%s:%d", serviceHost, port),
    Path:   req.Path,  // treated as data, never parsed as URL structure
}
if req.Query != "" {
    parsed, err := neturl.ParseQuery(req.Query)
    ...
    targetURL.RawQuery = parsed.Encode()
}
serviceURL := targetURL.String()
```

- `url.URL` struct assignment means `@`, `?`, `#` in `req.Path` are percent-encoded, not interpreted as URL structure
- `validatePath()` (already exists) blocks `..` and `://` before construction
- `url.ParseQuery` + `Encode()` re-encodes query values, neutralising injection attempts

## Test plan

- [ ] Normal proxy request (`/api/v1/pods`) still works correctly
- [ ] Path containing `@` is rejected by `validatePath` or encoded harmlessly
- [ ] Path containing `..` is rejected by `validatePath`
- [ ] Query string is properly encoded and forwarded to the target service
- [ ] Confirm CodeQL alert #39 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)