### PR TITLE
fix: guard against integer overflow in WebSocket frame allocations (CodeQL #84)

### DIFF
--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -1086,6 +1086,10 @@ func (c *WebSocketClient) handleMessage(msg *WebSocketMessage) {
 					messageType = int(v)
 				}
 				if isValidWebSocketMessageType(messageType) {
+					if len(data) > math.MaxInt-1 {
+						c.logger.Warn("WebSocket data frame too large to frame, dropping")
+						return
+					}
 					framed := make([]byte, 1+len(data))
 					framed[0] = byte(messageType)
 					copy(framed[1:], data)
@@ -1570,6 +1574,9 @@ func (c *WebSocketClient) SendWebSocketData(ctx context.Context, requestID strin
 	}
 
 	// Encode the full WebSocket message (type + data)
+	if len(data) > math.MaxInt-1 {
+		return fmt.Errorf("WebSocket data frame too large (%d bytes)", len(data))
+	}
 	fullData := make([]byte, 1+len(data))
 	fullData[0] = byte(messageType)
 	copy(fullData[1:], data)


### PR DESCRIPTION
## Vulnerability

CodeQL alert [#84](https://github.com/PipeOpsHQ/pipeops-k8-agent/security/code-scanning/84) — `go/allocation-size-overflow` (CWE-190, High)

Two locations in `websocket_client.go` computed allocation sizes with `1+len(data)` where `data` is a caller-supplied byte slice:

```go
// Location 1 — WS proxy message normalisation (~L1089)
framed := make([]byte, 1+len(data))   // UNSAFE

// Location 2 — SendWebSocketData (~L1573)
fullData := make([]byte, 1+len(data)) // UNSAFE
```

If `len(data) == math.MaxInt`, adding `1` wraps to `-9223372036854775808` on 64-bit systems. Passing a negative size to `make` causes an immediate **runtime panic**, crashing the agent process.

## Fix

Add an explicit bound check before each allocation:

```go
if len(data) > math.MaxInt-1 {
    // Location 1: drop the frame and log
    c.logger.Warn("WebSocket data frame too large to frame, dropping")
    return

    // Location 2: return an error to the caller
    return fmt.Errorf("WebSocket data frame too large (%d bytes)", len(data))
}
```

`math` was already imported in the file — no new dependency.

## Test plan

- [ ] Normal WebSocket frames still forward correctly
- [ ] A crafted frame at `math.MaxInt` bytes is rejected without panicking
- [ ] Confirm CodeQL alert #84 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)