### PR TITLE
Fix/oci registry path and monitoring namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,7 +633,7 @@ jobs:
 
             ### Helm Chart (Recommended for Kubernetes)
             ```bash
-            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent \
+            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent/pipeops-agent \
               --version ${{ steps.version.outputs.new_version }} \
               --set agent.pipeops.token="your-pipeops-token" \
               --set agent.cluster.name="your-cluster-name"
@@ -735,7 +735,7 @@ jobs:
 
             ### Helm Chart (Recommended for Kubernetes)
             ```bash
-            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent \
+            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent/pipeops-agent \
               --version ${{ github.ref_name }} \
               --set agent.pipeops.token="your-pipeops-token" \
               --set agent.cluster.name="your-cluster-name"

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Deploy using the Helm chart:
 
 ```bash
 # Add repository (if published)
-helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
 helm repo update
 
 # Install with custom values

--- a/docs/advanced/talos.md
+++ b/docs/advanced/talos.md
@@ -53,7 +53,7 @@ For production deployments you should provision Talos nodes following the offici
    === "Helm"
 
     ```bash
-    helm upgrade --install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm upgrade --install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --namespace pipeops-system \
       --create-namespace \
       --set agent.pipeops.token="your-pipeops-token" \

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -401,7 +401,7 @@ See [PipeOps Gateway Proxy Documentation](../advanced/pipeops-gateway-proxy.md) 
     **Installation**:
     ```bash
     # Install the agent directly from GHCR
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set agent.pipeops.token="your-pipeops-token" \
       --set agent.cluster.name="your-cluster-name"
     ```
@@ -426,7 +426,7 @@ See [PipeOps Gateway Proxy Documentation](../advanced/pipeops-gateway-proxy.md) 
     EOF
 
     # Install with custom configuration
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent -f values-custom.yaml
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent -f values-custom.yaml
     ```
 
     **Uninstallation**:
@@ -715,10 +715,10 @@ kubectl rollout status deployment/pipeops-agent -n pipeops-system
 
 ```bash
 # Upgrade to latest version
-helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
 
 # Upgrade with custom values
-helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent -f values-custom.yaml
+helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent -f values-custom.yaml
 ```
 
 ## Next Steps

--- a/docs/getting-started/management.md
+++ b/docs/getting-started/management.md
@@ -102,10 +102,10 @@ pipeops-agent update history
 
     ```bash
     # Upgrade to latest version
-    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
     
     # Upgrade with custom values
-    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent -f values.yaml
+    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent -f values.yaml
     ```
 
 ### Post-Update Verification

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -47,7 +47,7 @@ Choose your preferred installation method:
 
     ```bash
     # Install agent directly from GHCR
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set agent.pipeops.token="your-pipeops-token" \
       --set agent.cluster.name="my-cluster"
     ```
@@ -327,7 +327,7 @@ Important metrics to watch:
 
 2. **Increase resource limits**:
    ```bash
-   helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+   helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
      --set resources.limits.memory=2Gi \
      --set resources.limits.cpu=1000m
    ```
@@ -341,7 +341,7 @@ Keep your agent updated with the latest features:
 ```bash
 # For Helm installations - update to latest version
 helm repo update
-helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
 
 # For kubectl installations - reapply manifest
 kubectl apply -f https://get.pipeops.dev/k8-agent.yaml
@@ -428,7 +428,7 @@ Now that your agent is running, explore these features:
     
     ```bash
     # Adjust resource limits via Helm
-    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set resources.limits.memory=2Gi \
       --set resources.limits.cpu=1000m
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,7 +146,7 @@ Choose the deployment method that fits your infrastructure:
     For Kubernetes-native deployments:
     
     ```bash
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set agent.pipeops.token="your-pipeops-token" \
       --set agent.cluster.name="your-cluster-name"
     ```

--- a/helm/pipeops-agent/templates/monitoring-namespace.yaml
+++ b/helm/pipeops-agent/templates/monitoring-namespace.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+{{- if and .Values.monitoring.enabled (ne .Values.monitoring.namespace .Release.Namespace) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.monitoring.namespace }}
+  labels:
+    name: {{ .Values.monitoring.namespace }}
+    app.kubernetes.io/name: {{ include "pipeops-agent.name" . }}
+    app.kubernetes.io/component: monitoring-namespace
+    {{- include "pipeops-agent.labels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/pipeops-agent/templates/monitoring-namespace.yaml
+++ b/helm/pipeops-agent/templates/monitoring-namespace.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-{{- if and .Values.monitoring.enabled (ne .Values.monitoring.namespace .Release.Namespace) }}
+{{- if and .Values.monitoring.enabled .Values.agent.autoInstallComponents (ne .Values.monitoring.namespace .Release.Namespace) }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/helm/pipeops-agent/templates/monitoring-proxy-role.yaml
+++ b/helm/pipeops-agent/templates/monitoring-proxy-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.monitoring.enabled -}}
+{{- if and .Values.monitoring.enabled .Values.agent.autoInstallComponents -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/pipeops-agent/templates/monitoring-proxy-rolebinding.yaml
+++ b/helm/pipeops-agent/templates/monitoring-proxy-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.monitoring.enabled -}}
+{{- if and .Values.monitoring.enabled .Values.agent.autoInstallComponents -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
## Overview
This PR addresses two critical issues with the Helm chart deployment and documentation for the PipeOps Kubernetes Agent:
1. **OCI Registry Path Inconsistency:** Standardizes the registry path across all documentation files and GitHub Action workflows to ensure they use the correct nested OCI package path.
2. **Monitoring Namespace Provisioning:** Automates the creation of the monitoring namespace within the Helm chart while respecting configuration flags (`autoInstallComponents` and `monitoring.enabled`).

---

## Changes

### 1. OCI Registry Path Fixes
* **CI/CD Workflows (`.github/workflows/ci.yml`):** Fixed release note generators to output the correct nested OCI registry path (`oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent`) instead of the root namespace.
* **Documentation & README:** Updated `README.md` and MkDocs files (`docs/index.md`, `docs/getting-started/installation.md`, `docs/getting-started/quick-start.md`, `docs/getting-started/management.md`, `docs/advanced/talos.md`) to use the working nested path, resolving `403 Forbidden` / `404 Not Found` installation errors.


### 2. Helm Monitoring Namespace Automation
* **Dynamic Namespace Template:** Added `helm/pipeops-agent/templates/monitoring-namespace.yaml` to dynamically provision the monitoring namespace (default: `pipeops-monitoring`) if it is different from the release namespace.
* **Conditional Configuration Guard:** Ensured that the monitoring namespace, proxy role (`monitoring-proxy-role.yaml`), and rolebinding (`monitoring-proxy-rolebinding.yaml`) are only created when:
  1. `rbac.create` is `true`
  2. `monitoring.enabled` is `true`
  3. `agent.autoInstallComponents` is `true`
  This prevents the Helm chart from looking for or attempting to create the `pipeops-monitoring` namespace during a default installation (`autoInstallComponents: false`).

---

## Verification & Testing
1. **Chart Linting:** Ran `helm lint helm/pipeops-agent` — `0 chart(s) failed`.
2. **Template Testing:** 
   * Ran `helm template helm/pipeops-agent --set agent.autoInstallComponents=true` and verified the `pipeops-monitoring` namespace and proxy RBAC roles were successfully rendered.
   * Ran `helm template helm/pipeops-agent --set agent.autoInstallComponents=false` and verified no monitoring namespace or proxy RBAC roles were generated.
