### PR TITLE
fix(helm): standardize OCI registry path + bootstrap monitoring namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,7 +633,7 @@ jobs:
 
             ### Helm Chart (Recommended for Kubernetes)
             ```bash
-            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent \
+            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent/pipeops-agent \
               --version ${{ steps.version.outputs.new_version }} \
               --set agent.pipeops.token="your-pipeops-token" \
               --set agent.cluster.name="your-cluster-name"
@@ -735,7 +735,7 @@ jobs:
 
             ### Helm Chart (Recommended for Kubernetes)
             ```bash
-            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent \
+            helm install pipeops-agent oci://${{ env.REGISTRY }}/${{ steps.repo.outputs.owner_lower }}/pipeops-agent/pipeops-agent \
               --version ${{ github.ref_name }} \
               --set agent.pipeops.token="your-pipeops-token" \
               --set agent.cluster.name="your-cluster-name"

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Deploy using the Helm chart:
 
 ```bash
 # Add repository (if published)
-helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
 helm repo update
 
 # Install with custom values

--- a/docs/advanced/talos.md
+++ b/docs/advanced/talos.md
@@ -53,7 +53,7 @@ For production deployments you should provision Talos nodes following the offici
    === "Helm"
 
     ```bash
-    helm upgrade --install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm upgrade --install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --namespace pipeops-system \
       --create-namespace \
       --set agent.pipeops.token="your-pipeops-token" \

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -401,7 +401,7 @@ See [PipeOps Gateway Proxy Documentation](../advanced/pipeops-gateway-proxy.md) 
     **Installation**:
     ```bash
     # Install the agent directly from GHCR
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set agent.pipeops.token="your-pipeops-token" \
       --set agent.cluster.name="your-cluster-name"
     ```
@@ -426,7 +426,7 @@ See [PipeOps Gateway Proxy Documentation](../advanced/pipeops-gateway-proxy.md) 
     EOF
 
     # Install with custom configuration
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent -f values-custom.yaml
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent -f values-custom.yaml
     ```
 
     **Uninstallation**:
@@ -715,10 +715,10 @@ kubectl rollout status deployment/pipeops-agent -n pipeops-system
 
 ```bash
 # Upgrade to latest version
-helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
 
 # Upgrade with custom values
-helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent -f values-custom.yaml
+helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent -f values-custom.yaml
 ```
 
 ## Next Steps

--- a/docs/getting-started/management.md
+++ b/docs/getting-started/management.md
@@ -102,10 +102,10 @@ pipeops-agent update history
 
     ```bash
     # Upgrade to latest version
-    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
     
     # Upgrade with custom values
-    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent -f values.yaml
+    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent -f values.yaml
     ```
 
 ### Post-Update Verification

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -47,7 +47,7 @@ Choose your preferred installation method:
 
     ```bash
     # Install agent directly from GHCR
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set agent.pipeops.token="your-pipeops-token" \
       --set agent.cluster.name="my-cluster"
     ```
@@ -327,7 +327,7 @@ Important metrics to watch:
 
 2. **Increase resource limits**:
    ```bash
-   helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+   helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
      --set resources.limits.memory=2Gi \
      --set resources.limits.cpu=1000m
    ```
@@ -341,7 +341,7 @@ Keep your agent updated with the latest features:
 ```bash
 # For Helm installations - update to latest version
 helm repo update
-helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent
+helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent
 
 # For kubectl installations - reapply manifest
 kubectl apply -f https://get.pipeops.dev/k8-agent.yaml
@@ -428,7 +428,7 @@ Now that your agent is running, explore these features:
     
     ```bash
     # Adjust resource limits via Helm
-    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm upgrade pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set resources.limits.memory=2Gi \
       --set resources.limits.cpu=1000m
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,7 +146,7 @@ Choose the deployment method that fits your infrastructure:
     For Kubernetes-native deployments:
     
     ```bash
-    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent \
+    helm install pipeops-agent oci://ghcr.io/pipeopshq/pipeops-agent/pipeops-agent \
       --set agent.pipeops.token="your-pipeops-token" \
       --set agent.cluster.name="your-cluster-name"
     ```

--- a/helm/pipeops-agent/templates/monitoring-namespace.yaml
+++ b/helm/pipeops-agent/templates/monitoring-namespace.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+{{- if and .Values.monitoring.enabled (ne .Values.monitoring.namespace .Release.Namespace) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.monitoring.namespace }}
+  labels:
+    name: {{ .Values.monitoring.namespace }}
+    app.kubernetes.io/name: {{ include "pipeops-agent.name" . }}
+    app.kubernetes.io/component: monitoring-namespace
+    {{- include "pipeops-agent.labels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/pipeops-agent/templates/monitoring-namespace.yaml
+++ b/helm/pipeops-agent/templates/monitoring-namespace.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-{{- if and .Values.monitoring.enabled (ne .Values.monitoring.namespace .Release.Namespace) }}
+{{- if and .Values.monitoring.enabled .Values.agent.autoInstallComponents (ne .Values.monitoring.namespace .Release.Namespace) }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/helm/pipeops-agent/templates/monitoring-proxy-role.yaml
+++ b/helm/pipeops-agent/templates/monitoring-proxy-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.monitoring.enabled -}}
+{{- if and .Values.monitoring.enabled .Values.agent.autoInstallComponents -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/pipeops-agent/templates/monitoring-proxy-rolebinding.yaml
+++ b/helm/pipeops-agent/templates/monitoring-proxy-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.monitoring.enabled -}}
+{{- if and .Values.monitoring.enabled .Values.agent.autoInstallComponents -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
Re-submission of [#142](https://github.com/PipeOpsHQ/pipeops-k8-agent/pull/142) onto a properly-named branch that follows the repo convention (`fix/<descriptive-kebab>`, no `and` connector, scoped to the affected subsystem).

Original work by @Roslaan001 — full credit. This PR is the same 9 commits at `ba07418c`, just landed on a branch name that matches the repo's existing pattern (e.g. `fix/helm-namespace-ownership-metadata`, `fix/skip-monitoring-bootstrap-when-disabled`, `fix/wait-for-ingress-controller-service`).

## Overview

Addresses two coupled issues with the Helm chart deployment and documentation for the PipeOps Kubernetes Agent:

1. **OCI registry path inconsistency** — standardizes the Helm OCI registry path across `README.md`, `docs/index.md`, `docs/getting-started/{installation,quick-start,management}.md`, `docs/advanced/talos.md`, and `.github/workflows/ci.yml`.
2. **Monitoring namespace bootstrap** — ensures the `pipeops-monitoring` namespace is created by the chart (`helm/pipeops-agent/templates/monitoring-namespace.yaml`) and adjusts the proxy role + rolebinding to scope correctly; skipped when `autoInstallComponents` is false (see commit `ba07418`).

## Files changed (10)

- `.github/workflows/ci.yml` (+2/-2)
- `README.md` (+1/-1)
- `docs/advanced/talos.md` (+1/-1)
- `docs/getting-started/installation.md` (+4/-4)
- `docs/getting-started/management.md` (+2/-2)
- `docs/getting-started/quick-start.md` (+4/-4)
- `docs/index.md` (+1/-1)
- `helm/pipeops-agent/templates/monitoring-namespace.yaml` (+13/-0)
- `helm/pipeops-agent/templates/monitoring-proxy-role.yaml` (+1/-1)
- `helm/pipeops-agent/templates/monitoring-proxy-rolebinding.yaml` (+1/-1)

## Why the rename

- Original branch on the fork was `fix/oci-registry-path-and-monitoring` — the `and` connector and the trailing vague `monitoring` segment don't match the repo's naming convention (every recent merged `fix/` branch is single-concern + descriptive: `fix/instant-ingress-sync`, `fix/wait-for-ingress-controller-service`, `fix/lxc-containerd-slow-chown`, etc.).
- New name `fix/helm-oci-registry-monitoring-namespace` is scoped to the affected subsystem (`helm`), lists both subjects without a connector, and matches the kebab-case length other branches use.

## Carry-over notes

PR #141 was closed and re-submitted as PR #142; this branch carries the same `ba07418c` head as PR #142. After this PR opens, #142 will be closed with a pointer here.