### PR TITLE
fix(agent): self-heal monitoring/ingress bootstrap with retry backoff

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -936,9 +936,40 @@ func (a *Agent) startMonitoringBootstrap() {
 	go func() {
 		defer a.wg.Done()
 
-		if err := a.setupMonitoring(); err != nil {
-			a.logger.WithError(err).Warn("Failed to set up monitoring stack in background")
-			return
+		// Self-heal: retry monitoring/ingress setup with capped exponential
+		// backoff until it succeeds or the agent shuts down. Previously a single
+		// failed attempt left the stack un-installed until a manual
+		// `pipeops agent update` (which simply restarts the pod); now the agent
+		// recovers on its own. setupMonitoring is idempotent — the components
+		// manager's Start() skips already-healthy releases — and is a no-op once
+		// the stack is ready.
+		const (
+			initialBootstrapBackoff = 30 * time.Second
+			maxBootstrapBackoff     = 10 * time.Minute
+		)
+		backoff := initialBootstrapBackoff
+		for attempt := 1; ; attempt++ {
+			if err := a.setupMonitoring(); err == nil {
+				break
+			} else {
+				a.logger.WithError(err).WithFields(logrus.Fields{
+					"attempt":  attempt,
+					"retry_in": backoff.String(),
+				}).Warn("Monitoring stack setup failed; will retry (self-heal)")
+			}
+
+			select {
+			case <-a.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+
+			if backoff < maxBootstrapBackoff {
+				backoff *= 2
+				if backoff > maxBootstrapBackoff {
+					backoff = maxBootstrapBackoff
+				}
+			}
 		}
 
 		a.monitoringMutex.RLock()
@@ -971,14 +1002,19 @@ func (a *Agent) startMonitoringBootstrap() {
 
 // setupMonitoring initializes and starts the monitoring stack
 func (a *Agent) setupMonitoring() error {
-	// Check if monitoring has already been set up in this process
+	// Skip only if the stack has already been successfully set up. We
+	// deliberately gate on monitoringReady (terminal success) rather than a
+	// "setup started" flag, so that after a failed attempt the bootstrap retry
+	// loop can re-enter and self-heal. monitoringSetup is kept as an
+	// "attempted at least once" signal but no longer blocks re-entry.
 	a.monitoringMutex.Lock()
-	if a.monitoringSetup {
+	if a.monitoringReady {
 		a.monitoringMutex.Unlock()
 		a.logger.Debug("Monitoring stack already set up, skipping")
 		return nil
 	}
 	a.monitoringSetup = true
+	alreadyInitialized := a.monitoringMgr != nil
 	a.monitoringMutex.Unlock()
 
 	// Check if auto-installation is enabled (set by installer script)
@@ -988,31 +1024,40 @@ func (a *Agent) setupMonitoring() error {
 		return nil
 	}
 
-	a.logger.Info("Auto-installation enabled - initializing components stack (monitoring, ingress, metrics)...")
+	// Build the components manager once; retries reuse it (Start is idempotent).
+	if !alreadyInitialized {
+		a.logger.Info("Auto-installation enabled - initializing components stack (monitoring, ingress, metrics)...")
 
-	// Create components manager with default monitoring configuration
-	stack := components.DefaultMonitoringStack()
-	a.configureGrafanaSubPath(stack)
+		// Create components manager with default monitoring configuration
+		stack := components.DefaultMonitoringStack()
+		a.configureGrafanaSubPath(stack)
 
-	mgr, err := components.NewManager(stack, a.logger)
-	if err != nil {
-		return fmt.Errorf("failed to create components manager: %w", err)
-	}
-
-	a.monitoringMgr = mgr
-
-	// Wire early-ready callback: start the ingress watcher / gateway proxy as
-	// soon as the ingress controller (Traefik) is up, instead of waiting for the
-	// entire monitoring stack (cert-manager, prometheus, loki) to finish.
-	if a.config.Agent.EnableIngressSync && a.k8sClient != nil {
-		mgr.OnIngressControllerReady = func() {
-			a.wg.Add(1)
-			go func() {
-				defer a.wg.Done()
-				a.gatewayProxyOnce.Do(a.initializeGatewayProxy)
-			}()
+		mgr, err := components.NewManager(stack, a.logger)
+		if err != nil {
+			return fmt.Errorf("failed to create components manager: %w", err)
 		}
+
+		// Wire early-ready callback: start the ingress watcher / gateway proxy as
+		// soon as the ingress controller (Traefik) is up, instead of waiting for the
+		// entire monitoring stack (cert-manager, prometheus, loki) to finish.
+		if a.config.Agent.EnableIngressSync && a.k8sClient != nil {
+			mgr.OnIngressControllerReady = func() {
+				a.wg.Add(1)
+				go func() {
+					defer a.wg.Done()
+					a.gatewayProxyOnce.Do(a.initializeGatewayProxy)
+				}()
+			}
+		}
+
+		a.monitoringMutex.Lock()
+		a.monitoringMgr = mgr
+		a.monitoringMutex.Unlock()
 	}
+
+	a.monitoringMutex.RLock()
+	mgr := a.monitoringMgr
+	a.monitoringMutex.RUnlock()
 
 	// Start components stack synchronously (blocking)
 	// This ensures we catch any initialization errors before proceeding


### PR DESCRIPTION
## Problem

When the components bootstrap (monitoring + ingress + metrics) hit an issue, the agent did **not** self-heal — it reported unhealthy and stayed that way until an operator ran `pipeops agent update` (which just restarts the pod, re-running setup from a fresh process).

Root cause: the bootstrap ran **exactly once**.
- `startMonitoringBootstrap` called `setupMonitoring` a single time; on error it logged a warning and `return`ed — no retry.
- `setupMonitoring` latched `monitoringSetup = true` on entry, so it could never re-run within the process.

The connection/heartbeat layer already self-heals (reconnect + `sendHeartbeatWithRetry` backoff). The components layer was the gap.

## Fix

Make the components bootstrap self-heal to match the connection layer:

- **`startMonitoringBootstrap`** now retries `setupMonitoring` with **capped exponential backoff (30s → 10m)** until it succeeds or the agent shuts down (`a.ctx` cancellation), instead of bailing after one failure.
- **`setupMonitoring`** gates its skip on `monitoringReady` (terminal success) rather than `monitoringSetup` (attempt marker), so a failed attempt can be re-entered. The components manager is **built once and reused** across retries (assignment now guarded by `monitoringMutex`); `Manager.Start()` is idempotent and skips already-healthy releases, so retrying is safe and cheap.

Disabled auto-install (`PIPEOPS_AUTO_INSTALL_COMPONENTS != true`) and already-ready remain no-ops — the loop breaks on the `nil` return.

## Why this is safe to retry

`Manager.Start()` detects existing installs and skips healthy releases (`"Release already healthy before this run, skipping readiness wait"`), and the gateway-proxy init is guarded by `sync.Once`, so re-running setup does not double-start watchers.

## Scope / follow-ups

- This recovers from **setup failures**. It does not yet add an *ongoing* periodic reconcile to heal drift *after* a successful setup (e.g. a component deleted/crashing hours later) — that would be a natural follow-up now that `Start()` is cheap to re-run.
- Pairs with the Traefik readiness/RBAC fix in the sibling PR (so retries do not stall 4 minutes on Traefik readiness).

## Test
- `go build` + `go vet ./internal/agent/...` pass (`-mod=mod`; repo has a pre-existing vendor desync, tracked separately).