### PR TITLE
test(agent): fix flaky TestWSStreamEntry_ConcurrentAccess

### DIFF
--- a/internal/agent/websocket_stream_test.go
+++ b/internal/agent/websocket_stream_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -240,7 +241,14 @@ func TestWSStreamEntry_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			reqID := "req-" + string(rune('A'+id%26)) + "-" + time.Now().Format(time.RFC3339Nano)
+			// Use the loop index as the key so every goroutine gets a unique
+			// reqID. The previous "letter + RFC3339Nano timestamp" scheme could
+			// collide (id%26 repeats past 26 goroutines, and two goroutines can
+			// format the same nanosecond), causing one entry to overwrite
+			// another in the map. handleWebSocketClose would then cancel the
+			// surviving entry, leaving the overwritten goroutine's context
+			// uncancelled and failing the assertion below intermittently.
+			reqID := fmt.Sprintf("req-%03d", id)
 			ctx, cancel := context.WithCancel(context.Background())
 
 			a.wsStreamsMu.Lock()


### PR DESCRIPTION
Fixes the intermittent failure:

```
--- FAIL: TestWSStreamEntry_ConcurrentAccess
    websocket_stream_test.go:262: An error is expected but got nil.
        Messages: context should be cancelled
```

## Root cause (flaky test, not a code bug)

Each of the 50 goroutines keyed its `wsStream` by `"req-" + <letter> + "-" + time.Now().Format(time.RFC3339Nano)`, where `<letter>` is `id%26`. Past 26 goroutines the letter repeats, so uniqueness relied entirely on the nanosecond timestamp — and two concurrent goroutines can format the **same nanosecond**.

On a key collision, one goroutine's `wsStreamEntry` overwrites another's in the map. `handleWebSocketClose(reqID)` then finds and cancels only the surviving entry, leaving the overwritten goroutine's context **uncancelled** → `ctx.Err()` is `nil` → the assertion fails. Reproduced ~1 in 10 runs locally.

Production code (`handleWebSocketClose` → `entry.cancel()`) is correct and unchanged.

## Fix

Key each goroutine by its unique loop index (`fmt.Sprintf("req-%03d", id)`). The test still exercises concurrent map reads/writes under the `RWMutex` (its stated purpose) but is now deterministic.

## Verification
- Before: ~1/10 runs FAIL.
- After: **30/30** runs pass; `go test -race -count=20` passes.

Note: build/test locally with `-mod=mod` due to the repo's pre-existing vendor desync (tracked separately).