### PR TITLE
ci: install Go toolchain matching go.mod (fixes 'no such tool covdata')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Cache Go modules
         uses: actions/cache@v4


### PR DESCRIPTION
The Test job fails with **exit 1 while every test package reports `ok`** — no `FAIL`, no panic, no race. The real error is buried in the verbose `go test` output:

```
# github.com/pipeops/pipeops-vm-agent/internal/helm
go: no such tool "covdata"
# github.com/pipeops/pipeops-vm-agent/pkg/types
go: no such tool "covdata"
```

## Root cause (CI toolchain cache corruption — not a code/test bug)

1. `go.mod` requires `go 1.25.0`, but `setup-go` pinned `go-version: "1.23"`.
2. Because the installed Go (1.23) is older than `go.mod`, Go's `GOTOOLCHAIN` auto-downloads the **1.25.0 toolchain** into `~/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0`.
3. The **Cache Go modules** step caches `~/go/pkg/mod`, so that toolchain gets cached. On restore it extracts **incompletely** — visible in the same log:
   ```
   /usr/bin/tar: .../go1.25.0/pkg/tool/linux_amd64/vet: Cannot open: File exists
   ##[warning]Failed to restore: "/usr/bin/tar" failed with error: ... exit code 2
   ```
4. The partial toolchain is missing tools including **`covdata`**, which `go test -coverprofile=coverage.out ./...` needs to write coverage for the **no-test-file** packages (`internal/helm`, `pkg/types`) → `no such tool "covdata"` → exit 1, even though all tests pass.

## Fix

Use `go-version-file: go.mod` in all three `setup-go` steps. setup-go then installs the full **1.25.x** toolchain cleanly (with `covdata`, `vet`, etc.), and Go never needs to download a toolchain into the corruptible module cache.

## Why this is the right fix
- The tests themselves pass — verified locally with `go test -race ./...` (module mode, matching CI) across many runs.
- Keeping `setup-go`'s Go version in sync with `go.mod` is the standard way to avoid `GOTOOLCHAIN` runtime downloads landing in the module cache.

No application code changed.