### PR TITLE
style: gofmt -s websocket_client.go to fix CI formatting check

### DIFF
--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -1870,9 +1870,9 @@ func (c *WebSocketClient) reconnectLoop() {
 
 		disconnected := c.DisconnectedDuration()
 		c.logger.WithFields(logrus.Fields{
-			"attempt":             attempt,
-			"error":               err,
-			"disconnected_for":    disconnected,
+			"attempt":          attempt,
+			"error":            err,
+			"disconnected_for": disconnected,
 		}).Warn("Reconnection failed, will retry with backoff")
 
 		// Exponential backoff capped at maxDelay


### PR DESCRIPTION
## What

Run `gofmt -s -w` on `internal/controlplane/websocket_client.go` to realign a `logrus.Fields` struct literal whose keys were misaligned.

## Why

The CI `Test` job's **Check formatting** step (`gofmt -s -l . | grep -v '^vendor/'`) was failing on `main`:

```
Code is not formatted. Please run 'go fmt ./...'
internal/controlplane/websocket_client.go
```

This step only started failing once #148 (the Go toolchain / `covdata` fix) unblocked the earlier **Run tests** step — the formatting failure was sitting underneath and is the last thing keeping main's CI/CD Pipeline red.

## Scope

Pure `gofmt -s` realignment — no logic change (3 lines, whitespace only). Verified `gofmt -s -l` is now clean and the package builds.