### PR TITLE
build: bump builder image to golang:1.25-alpine (go.mod requires go 1.25.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata


### PR DESCRIPTION
Fixes the Docker build failure:

```
#13 [builder 6/11] RUN go mod download && go mod verify
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download && go mod verify" did not complete successfully: exit code: 1
```

## Cause
`go.mod` declares `go 1.25.0`, but the builder stage pinned `golang:1.24-alpine`. With `GOTOOLCHAIN=local` the build cannot fetch a newer toolchain, so `go mod download` aborts.

## Fix
Bump the builder base image to `golang:1.25-alpine` (verified `go1.25.8`, satisfies `>= 1.25.0`). `Dockerfile.dev` is already on `golang:1.25.4-alpine`, so this just brings the production build image in line.

Verified: `docker run --rm golang:1.25-alpine go version` → `go1.25.8`.