### PR TITLE
feat(agent): daemon (non-k8s) origin mode — config + SSRF guard [Phase 0–2]

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -53,6 +53,10 @@ func init() {
 	rootCmd.Flags().String("kubeconfig", "", "Path to kubeconfig file")
 	rootCmd.Flags().Bool("in-cluster", false, "Run in cluster mode")
 
+	// Daemon mode: run as a host daemon forwarding to local origins (no Kubernetes)
+	rootCmd.Flags().Bool("daemon", false, "Run as a host daemon: forward tunneled traffic to local origins instead of Kubernetes Services")
+	rootCmd.Flags().String("daemon-default-origin", "", "Fallback local origin in daemon mode, e.g. localhost:3000")
+
 	// Gateway flags (top-level toggles and basic settings)
 	rootCmd.Flags().Bool("gateway-enabled", false, "Enable env-aware TCP/UDP gateway")
 	rootCmd.Flags().String("gateway-namespace", "pipeops-system", "Namespace for gateway Helm release")
@@ -95,6 +99,13 @@ func init() {
 	}
 	if err := viper.BindPFlag("kubernetes.in_cluster", rootCmd.Flags().Lookup("in-cluster")); err != nil {
 		logrus.Fatalf("Failed to bind in-cluster flag: %v", err)
+	}
+
+	if err := viper.BindPFlag("daemon.enabled", rootCmd.Flags().Lookup("daemon")); err != nil {
+		logrus.Fatalf("Failed to bind daemon flag: %v", err)
+	}
+	if err := viper.BindPFlag("daemon.default_origin", rootCmd.Flags().Lookup("daemon-default-origin")); err != nil {
+		logrus.Fatalf("Failed to bind daemon-default-origin flag: %v", err)
 	}
 
 	// Bind gateway flags - collect errors for batch reporting
@@ -165,6 +176,8 @@ func initConfig() {
 	viper.BindEnv("agent.enable_ingress_sync", "ENABLE_INGRESS_SYNC")
 	viper.BindEnv("kubernetes.service_token", "PIPEOPS_K8S_SERVICE_TOKEN")
 	viper.BindEnv("kubernetes.ca_cert_data", "PIPEOPS_K8S_CERT_DATA")
+	viper.BindEnv("daemon.enabled", "PIPEOPS_DAEMON_ENABLED")
+	viper.BindEnv("daemon.default_origin", "PIPEOPS_DAEMON_ORIGIN")
 
 	// Gateway env overrides (no prefix, simple names)
 	bindEnv := func(key, env string) {

--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -1,6 +1,6 @@
 # Daemon mode — running the PipeOps connector outside Kubernetes (cloudflared-style)
 
-Status: design / proposal. Goal: let the existing agent run as a **host daemon** (VM, bare metal,
+Status: Phase 0–1 implemented; Phase 2 partial (see "Implementation status" below). Goal: let the existing agent run as a **host daemon** (VM, bare metal,
 Docker, laptop) that tunnels arbitrary local origins (`localhost:port`, `host:port`, unix socket),
 in addition to its current in-cluster mode — without changing the gateway/control-plane side.
 
@@ -154,6 +154,35 @@ ingress:
   k8s client and disables component/metrics modules; clean startup with zero k8s API calls.
 - **Phase 3 (~few days):** build/packaging — a slim daemon binary (optional build tag to drop the
   k8s client-go deps for size), `pipeops tunnel run`-style UX, systemd unit, Docker image.
+
+## Implementation status
+
+- **Phase 0 — done.** `internal/origin` (`Dialer`, `ClusterDialer`, `HostDialer`); HTTP proxy path
+  resolves origins via the dialer.
+- **Phase 1 — done.** `OriginDialer` threaded to the L4 yamux path
+  (`agent → controlplane.Client → WebSocketClient → YamuxConfig`); per-host routing from the request
+  `Host`; multi-route `HostDialer`.
+- **Phase 2 — partial.** Config-driven routes shipped: a `daemon:` config section
+  (`enabled`/`default_origin`/`ingress`/`allowed_origins`), a `--daemon` flag, `PIPEOPS_DAEMON_*`
+  env, and an SSRF allowlist on `HostDialer`. See `examples/daemon-config.yaml`.
+  **Remaining:** config-file hot reload, local `FileStore` credentials/state, a slim build that drops
+  client-go via a build tag.
+
+### Configuration (shipped)
+
+```yaml
+daemon:
+  enabled: true
+  default_origin: "localhost:3000"
+  ingress:
+    - hostname: "app.example.com"
+      origin: "localhost:8080"
+  allowed_origins: ["localhost"]   # SSRF guard; empty = allow any configured origin
+```
+
+Equivalent quick-start via env: `PIPEOPS_DAEMON_ENABLED=true`, `PIPEOPS_DAEMON_ORIGIN=localhost:3000`,
+`PIPEOPS_DAEMON_ROUTES="app.example.com=localhost:8080"` (or the `--daemon` / `--daemon-default-origin`
+flags). `PIPEOPS_ORIGIN_MODE=host` remains accepted as a back-compat alias for enabling daemon mode.
 
 ## Risks / watch-items
 - **SSRF/allowlisting:** daemon dials arbitrary local addresses — keep the existing validation and add

--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -1,0 +1,165 @@
+# Daemon mode — running the PipeOps connector outside Kubernetes (cloudflared-style)
+
+Status: design / proposal. Goal: let the existing agent run as a **host daemon** (VM, bare metal,
+Docker, laptop) that tunnels arbitrary local origins (`localhost:port`, `host:port`, unix socket),
+in addition to its current in-cluster mode — without changing the gateway/control-plane side.
+
+## TL;DR
+The hard part (outbound multiplexed tunnel, registration, reconnect/resume, request_id muxing,
+yamux L4) is **already origin-agnostic**. Kubernetes coupling is concentrated in **three seams**:
+route discovery, origin dialing, and identity/state. The agent is already written defensively
+around a nil k8s client, L4 routes can already come from JSON flags, and there's a `--kubeconfig` /
+`--in-cluster` flag plus an in-memory state fallback. So this is **interface extraction + a run
+mode**, not new distributed-systems work. Estimate: a few focused weeks.
+
+## What already works in our favor (verified)
+- `internal/agent/agent.go` guards `if a.k8sClient != nil` at every k8s touchpoint
+  (e.g. lines ~387, 579, 763, 1043). Much of the agent already tolerates no cluster.
+- Ingress sync is already gated: `a.config.Agent.EnableIngressSync && a.k8sClient != nil`.
+- L4 routes can already be supplied as config, not just CRDs:
+  `--gateway-gwapi-tcp-routes-json`, `--gateway-istio-tcp-routes-json`, etc. (cmd/agent/main.go).
+- `cmd/agent/main.go` already has `--kubeconfig`, `--in-cluster`, a `--config` (viper) file.
+- `pkg/state` already supports ConfigMap **and** in-memory modes.
+- TCP/UDP tunnel handlers already dial `localhost:<port>` (`tcp_tunnel.go:29`, `udp_tunnel.go:66`)
+  and there's a generic reverse-tunnel primitive in `internal/tunnel/client.go`
+  (`LocalAddr`, `R:8000:localhost:6443`).
+- The gateway server (in `pipeops-controller/services/gateway/`) is **connector-agnostic** — it sees
+  a websocket + a connector UUID and routes by hostname. **Daemon mode needs zero gateway changes.**
+
+## The three seams (where Kubernetes is actually wired in)
+
+### 1. Route discovery — `RouteProvider`
+Today: only `internal/ingress/*` (watches K8s `Ingress` + Gateway-API `Gateway`/`TCPRoute`/`UDPRoute`).
+Daemon needs a config-file provider (cloudflared-style ingress rules).
+
+```go
+// internal/routes/provider.go
+type Route struct {
+    Hostname    string // public host the gateway routes by (HTTP/WS)
+    Path        string // optional path prefix
+    Origin      Origin // where the connector forwards to locally
+    TLS         bool
+}
+type Origin struct {
+    Scheme  string // http | https | tcp | udp | unix
+    Address string // "localhost:3000" | "/run/app.sock" | "127.0.0.1:5432"
+}
+type RouteProvider interface {
+    // Routes returns the current route table and pushes updates on change.
+    Routes(ctx context.Context) (<-chan []Route, error)
+}
+```
+Implementations:
+- `K8sIngressProvider` — wraps the existing `internal/ingress` watcher (no behavior change in-cluster).
+- `ConfigFileProvider` — reads `ingress:` from the agent config / `--ingress-json`, watches the file.
+- (later) `APIProvider` — routes pushed from the control plane.
+
+Both feed the **same** `SyncIngresses` call to the gateway (`internal/ingress/client.go`), so the
+gateway route registry is identical regardless of source.
+
+### 2. Origin dialing — `OriginDialer`
+Today: two hard-coded cluster-DNS sites:
+- HTTP: `internal/agent/agent.go` → `buildServiceFQDN(ServiceName, Namespace)` → `*.svc.cluster.local`
+  (used in `proxyToService`, agent.go:2694).
+- L4: `internal/tunnel/yamux_client.go:190` → `fmt.Sprintf("%s.%s.svc.cluster.local:%d", ...)`.
+
+```go
+// internal/origin/dialer.go
+type Target struct {
+    Protocol string // tcp | udp
+    // In k8s mode: ServiceName/Namespace/Port. In daemon mode: Address.
+    ServiceName, Namespace string
+    Port                   int
+    Address                string // explicit host:port / unix path (daemon)
+}
+type OriginDialer interface {
+    DialContext(ctx context.Context, t Target) (net.Conn, error)
+    // ResolveHTTPHost returns scheme+host:port for the HTTP proxy path.
+    ResolveHTTPHost(t Target) (scheme, hostport string, err error)
+}
+```
+Implementations:
+- `ClusterDialer` — current behavior: `buildServiceFQDN` + `svc.cluster.local`. Keeps SSRF
+  validation (`validateServiceName/Namespace/Port`).
+- `HostDialer` — daemon: dials `Target.Address` (host:port or `unix://`), still validated/allowlisted.
+
+Refactor: replace the two hard-coded dial sites with `a.originDialer.DialContext(...)` /
+`ResolveHTTPHost(...)`. The route table (seam 1) supplies `Target.Address` in daemon mode.
+
+### 3. Identity & state — `Identity` + `StateStore`
+Today: `rest.InClusterConfig()` (`pkg/k8s/client.go:42`, `controlplane/websocket_proxy.go:186`) +
+ConfigMap-backed `pkg/state`.
+
+```go
+type StateStore interface { // already largely exists in pkg/state
+    GetClusterID() (string, error); SaveClusterID(string) error
+    GetGatewayWSURL() (string, error); SaveGatewayWSURL(string) error
+    Clear() error
+}
+```
+- `ConfigMapStore` — current.
+- `FileStore` — daemon: `~/.pipeops-agent/state.json` (creds + clusterID + cached gateway URL),
+  mirroring cloudflared's `credentials.json` + tunnel token. The in-memory fallback already exists.
+- Auth token: daemon reads it from `--token` / config / a credentials file (already supported).
+  The gateway already accepts the connector token by `Authorization: Bearer` — unchanged.
+
+### Plus: skip the k8s-only modules in daemon mode
+- Component bootstrap (Helm install Traefik/cert-manager/Prometheus/Loki) — already gated by
+  `PIPEOPS_AUTO_INSTALL_COMPONENTS`; daemon mode forces it off.
+- K8s-API proxying (`kubectl exec`/API) and cluster metrics — only registered when `k8sClient != nil`.
+- `monitoringMgr`, ingress watcher — only started in k8s mode.
+
+## Run mode wiring
+Add `--mode=k8s|daemon` (default `k8s`; infer `daemon` when no kubeconfig and not in-cluster).
+In `cmd/agent/main.go` / agent construction, pick implementations:
+
+| Component       | k8s mode                | daemon mode             |
+|-----------------|-------------------------|-------------------------|
+| RouteProvider   | K8sIngressProvider      | ConfigFileProvider      |
+| OriginDialer    | ClusterDialer           | HostDialer              |
+| StateStore      | ConfigMapStore          | FileStore               |
+| k8sClient       | NewInClusterClient      | nil (guards already exist) |
+| Components/metrics | on (gated)           | off                     |
+
+Everything else — `internal/controlplane/*` (registration, WS protocol, heartbeat, reconnect/resume,
+request_id mux, proxy_request/response framing) and `internal/tunnel/*` (yamux, wsconn, stream
+headers) — is **reused unchanged**.
+
+## Config schema (daemon)
+```yaml
+# ~/.pipeops-agent.yaml
+pipeops:
+  api_url: https://api.pipeops.io
+  token: <connector-token>
+agent:
+  id: my-vm-1
+  mode: daemon
+ingress:
+  - hostname: app.example.com
+    origin: { scheme: http, address: localhost:3000 }
+  - hostname: db.example.com           # L4
+    origin: { scheme: tcp,  address: localhost:5432 }
+  - hostname: api.example.com
+    path: /v1
+    origin: { scheme: http, address: 127.0.0.1:8080 }
+```
+
+## Phased plan
+- **Phase 0 (spike, ~days):** swap the two dial sites behind `OriginDialer`; hard-code a `HostDialer`
+  to one `localhost:port`; prove an HTTP request flows gateway → daemon (no k8s) → local service.
+  This de-risks the whole effort by validating the gateway is truly connector-agnostic.
+- **Phase 1 (~1–1.5 wk):** `RouteProvider` + `ConfigFileProvider` (config-driven HTTP/WS + L4 routes),
+  feeding the existing `SyncIngresses`. Unify the `OriginDialer` across HTTP and yamux paths.
+- **Phase 2 (~1 wk):** `StateStore`/`FileStore` + local credentials; `--mode=daemon` that nils the
+  k8s client and disables component/metrics modules; clean startup with zero k8s API calls.
+- **Phase 3 (~few days):** build/packaging — a slim daemon binary (optional build tag to drop the
+  k8s client-go deps for size), `pipeops tunnel run`-style UX, systemd unit, Docker image.
+
+## Risks / watch-items
+- **SSRF/allowlisting:** daemon dials arbitrary local addresses — keep the existing validation and add
+  an origin allowlist from config (don't let the gateway pick arbitrary hosts).
+- **Transport:** still WS+yamux (TCP-over-TCP). Fine on clean links; the QUIC upgrade is a separate,
+  larger effort (orthogonal to k8s decoupling) and the real perf moat.
+- **Feature parity:** `kubectl exec`/API proxying is inherently k8s; daemon mode simply omits it.
+- The decoupling is the easy half. The expensive half — a global anycast edge + QUIC — is unchanged
+  by this work.

--- a/examples/daemon-config.yaml
+++ b/examples/daemon-config.yaml
@@ -1,0 +1,37 @@
+# Example: run the PipeOps connector as a host daemon (cloudflared-style).
+#
+# In daemon mode the agent does NOT resolve Kubernetes Services via cluster DNS.
+# Instead it forwards tunneled traffic (HTTP and L4 TCP/UDP) to local origins.
+# Enable with `daemon.enabled: true`, the `--daemon` flag, or PIPEOPS_DAEMON_ENABLED=true.
+#
+# Place at $HOME/.pipeops-agent.yaml, /etc/pipeops/.pipeops-agent.yaml, or pass --config.
+
+pipeops:
+  api_url: "wss://gateway.pipeops.io"
+  token: "${PIPEOPS_TOKEN}"
+
+agent:
+  cluster_name: "edge-daemon-1"
+
+daemon:
+  enabled: true
+
+  # Fallback origin used for any hostname not matched by an ingress rule below.
+  default_origin: "localhost:3000"
+
+  # Per-hostname routes (the public Host the request arrived for -> local origin).
+  # Origins are host:port, or unix:///path/to.sock.
+  ingress:
+    - hostname: "app.example.com"
+      origin: "localhost:8080"
+    - hostname: "api.example.com"
+      origin: "localhost:9000"
+    - hostname: "db.example.com"
+      origin: "unix:///run/postgres.sock"
+
+  # SSRF guard: when non-empty, the daemon may ONLY dial these addresses.
+  # Entries are "host:port", a bare "host" (any port), or "unix:///path".
+  # Leave empty to allow any address configured above (trusted-config mode).
+  allowed_origins:
+    - "localhost"
+    - "unix:///run/postgres.sock"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pipeops/pipeops-vm-agent/internal/controlplane"
 	"github.com/pipeops/pipeops-vm-agent/internal/helm"
 	"github.com/pipeops/pipeops-vm-agent/internal/ingress"
+	"github.com/pipeops/pipeops-vm-agent/internal/origin"
 	"github.com/pipeops/pipeops-vm-agent/internal/server"
 	"github.com/pipeops/pipeops-vm-agent/internal/tunnel"
 	"github.com/pipeops/pipeops-vm-agent/internal/version"
@@ -165,6 +166,7 @@ type Agent struct {
 	stateManager   *state.StateManager     // Manages persistent state
 	k8sClient      *k8s.Client             // Kubernetes client for in-cluster API access
 	gatewayWatcher *ingress.IngressWatcher // Gateway proxy ingress watcher (for private clusters)
+	originDialer   origin.Dialer           // Resolves/dials the request origin (cluster Service vs daemon host:port)
 
 	// TCP/UDP tunneling via Gateway API (new architecture)
 	tcpUDPTunnelMgr     *TunnelManager            // TCP/UDP tunnel connection manager
@@ -483,6 +485,21 @@ func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 		}).Info("TCP/UDP tunneling enabled via Gateway API")
 	} else {
 		logger.Info("TCP/UDP tunneling disabled")
+	}
+
+	// Origin dialer: where tunneled requests are forwarded. Default is the
+	// in-cluster behaviour (resolve Kubernetes Services via cluster DNS). When
+	// PIPEOPS_ORIGIN_MODE=host (daemon mode), forward to a local address instead
+	// (PIPEOPS_DAEMON_ORIGIN, e.g. "localhost:3000") — no Kubernetes required.
+	// This is the seam that lets the same binary run as a cloudflared-style host
+	// daemon; full daemon-mode wiring (config-file routes, local state) is a
+	// follow-up.
+	if strings.EqualFold(os.Getenv("PIPEOPS_ORIGIN_MODE"), "host") {
+		defaultOrigin := os.Getenv("PIPEOPS_DAEMON_ORIGIN")
+		agent.originDialer = origin.NewHostDialer(defaultOrigin, nil)
+		logger.WithField("default_origin", defaultOrigin).Info("Origin mode: HOST (daemon) — forwarding to local address, Kubernetes Service resolution disabled")
+	} else {
+		agent.originDialer = origin.NewClusterDialer(getClusterDNSDomain())
 	}
 
 	return agent, nil
@@ -2734,18 +2751,30 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 		return 0, nil, nil, fmt.Errorf("invalid path: %w", err)
 	}
 
-	// Construct the URL for the in-cluster service using url.URL so that
-	// user-controlled values (path, query) are always treated as data, never
-	// as URL structure. fmt.Sprintf concatenation allows "@" in the path to
-	// rewrite the host (e.g. "http://svc:80@evil.com/x").
-	serviceHost := buildServiceFQDN(req.ServiceName, req.Namespace)
+	// Resolve the origin host:port via the origin dialer. In cluster mode this
+	// yields "<svc>.<ns>.svc.<clusterDomain>:<port>" (unchanged behaviour); in
+	// daemon mode it yields the configured local address. Using url.URL keeps
+	// user-controlled values (path, query) as data, never URL structure
+	// (fmt.Sprintf concatenation would let "@" in the path rewrite the host,
+	// e.g. "http://svc:80@evil.com/x").
+	hostPort, err := a.originDialer.HTTPHostPort(origin.Target{
+		ServiceName: req.ServiceName,
+		Namespace:   req.Namespace,
+		Port:        int(req.ServicePort),
+	})
+	if err != nil {
+		if body != nil {
+			_ = body.Close()
+		}
+		return 0, nil, nil, fmt.Errorf("resolve origin: %w", err)
+	}
 	httpScheme := "http"
 	if req.Scheme == "https" {
 		httpScheme = "https"
 	}
 	targetURL := &neturl.URL{
 		Scheme: httpScheme,
-		Host:   fmt.Sprintf("%s:%d", serviceHost, req.ServicePort),
+		Host:   hostPort,
 		Path:   req.Path,
 	}
 	if req.Query != "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -489,19 +489,17 @@ func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 
 	// Origin dialer: where tunneled requests are forwarded. Default is the
 	// in-cluster behaviour (resolve Kubernetes Services via cluster DNS). When
-	// PIPEOPS_ORIGIN_MODE=host (daemon mode), forward to a local address instead
-	// (PIPEOPS_DAEMON_ORIGIN, e.g. "localhost:3000") — no Kubernetes required.
-	// This is the seam that lets the same binary run as a cloudflared-style host
-	// daemon; full daemon-mode wiring (config-file routes, local state) is a
-	// follow-up.
-	if strings.EqualFold(os.Getenv("PIPEOPS_ORIGIN_MODE"), "host") {
-		defaultOrigin := os.Getenv("PIPEOPS_DAEMON_ORIGIN")
-		routes := parseDaemonRoutes(os.Getenv("PIPEOPS_DAEMON_ROUTES"))
-		agent.originDialer = origin.NewHostDialer(defaultOrigin, routes)
+	// daemon mode is enabled (config `daemon.enabled` or PIPEOPS_ORIGIN_MODE=host),
+	// forward to local origins instead — no Kubernetes required. This is the seam
+	// that lets the same binary run as a cloudflared-style host daemon.
+	if daemonOriginEnabled(config) {
+		hd := buildHostDialer(config)
+		agent.originDialer = hd
 		logger.WithFields(logrus.Fields{
-			"default_origin": defaultOrigin,
-			"routes":         len(routes),
-		}).Info("Origin mode: HOST (daemon) — forwarding to local addresses; Kubernetes Service resolution disabled")
+			"default_origin": hd.DefaultAddress,
+			"routes":         len(hd.Routes),
+			"allowlist":      len(hd.AllowedOrigins),
+		}).Info("Origin mode: HOST (daemon) — forwarding to local origins; Kubernetes Service resolution disabled")
 	} else {
 		agent.originDialer = origin.NewClusterDialer(getClusterDNSDomain())
 	}
@@ -527,6 +525,48 @@ func requestHost(req *controlplane.ProxyRequest) string {
 		}
 	}
 	return ""
+}
+
+// daemonOriginEnabled reports whether the connector should run in host-daemon
+// mode (forward to local origins) rather than resolving Kubernetes Services.
+// Config `daemon.enabled` takes precedence; PIPEOPS_ORIGIN_MODE=host is the
+// env-only fallback for quick/spike usage.
+func daemonOriginEnabled(config *types.Config) bool {
+	if config != nil && config.Daemon != nil && config.Daemon.Enabled {
+		return true
+	}
+	return strings.EqualFold(os.Getenv("PIPEOPS_ORIGIN_MODE"), "host")
+}
+
+// buildHostDialer constructs the daemon origin dialer from config, with env
+// fallbacks. Config ingress rules and `default_origin` take precedence over the
+// PIPEOPS_DAEMON_* env vars; env routes are merged in for any hosts the config
+// doesn't cover.
+func buildHostDialer(config *types.Config) *origin.HostDialer {
+	defaultOrigin := os.Getenv("PIPEOPS_DAEMON_ORIGIN")
+	routes := parseDaemonRoutes(os.Getenv("PIPEOPS_DAEMON_ROUTES"))
+	var allowed []string
+
+	if config != nil && config.Daemon != nil {
+		d := config.Daemon
+		if d.DefaultOrigin != "" {
+			defaultOrigin = d.DefaultOrigin
+		}
+		for _, r := range d.Ingress {
+			if r.Hostname == "" || r.Origin == "" {
+				continue
+			}
+			if routes == nil {
+				routes = make(map[string]string)
+			}
+			routes[r.Hostname] = r.Origin // config wins over env for the same host
+		}
+		allowed = d.AllowedOrigins
+	}
+
+	hd := origin.NewHostDialer(defaultOrigin, routes)
+	hd.AllowedOrigins = allowed
+	return hd
 }
 
 // parseDaemonRoutes parses a "host=addr,host2=addr2" string (PIPEOPS_DAEMON_ROUTES)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -496,13 +496,62 @@ func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 	// follow-up.
 	if strings.EqualFold(os.Getenv("PIPEOPS_ORIGIN_MODE"), "host") {
 		defaultOrigin := os.Getenv("PIPEOPS_DAEMON_ORIGIN")
-		agent.originDialer = origin.NewHostDialer(defaultOrigin, nil)
-		logger.WithField("default_origin", defaultOrigin).Info("Origin mode: HOST (daemon) — forwarding to local address, Kubernetes Service resolution disabled")
+		routes := parseDaemonRoutes(os.Getenv("PIPEOPS_DAEMON_ROUTES"))
+		agent.originDialer = origin.NewHostDialer(defaultOrigin, routes)
+		logger.WithFields(logrus.Fields{
+			"default_origin": defaultOrigin,
+			"routes":         len(routes),
+		}).Info("Origin mode: HOST (daemon) — forwarding to local addresses; Kubernetes Service resolution disabled")
 	} else {
 		agent.originDialer = origin.NewClusterDialer(getClusterDNSDomain())
 	}
+	// Propagate to the control-plane client so L4 (yamux) tunnels resolve their
+	// target the same way the HTTP path does. nil-safe in standalone mode.
+	if agent.controlPlane != nil {
+		agent.controlPlane.SetOriginDialer(agent.originDialer)
+	}
 
 	return agent, nil
+}
+
+// requestHost returns the public Host the proxied request arrived for, used as
+// the per-host routing key in daemon mode. Checks the Host header (the gateway
+// forwards the original Host); empty when absent.
+func requestHost(req *controlplane.ProxyRequest) string {
+	if req == nil || req.Headers == nil {
+		return ""
+	}
+	for _, k := range []string{"Host", "host", "X-Forwarded-Host"} {
+		if v, ok := req.Headers[k]; ok && len(v) > 0 && v[0] != "" {
+			return v[0]
+		}
+	}
+	return ""
+}
+
+// parseDaemonRoutes parses a "host=addr,host2=addr2" string (PIPEOPS_DAEMON_ROUTES)
+// into a hostname -> local-origin-address map for daemon mode. Blank/invalid
+// entries are skipped.
+func parseDaemonRoutes(s string) map[string]string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	routes := make(map[string]string)
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		host, addr, ok := strings.Cut(pair, "=")
+		host = strings.TrimSpace(host)
+		addr = strings.TrimSpace(addr)
+		if !ok || host == "" || addr == "" {
+			continue
+		}
+		routes[host] = addr
+	}
+	if len(routes) == 0 {
+		return nil
+	}
+	return routes
 }
 
 // Start starts the agent
@@ -2761,6 +2810,7 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 		ServiceName: req.ServiceName,
 		Namespace:   req.Namespace,
 		Port:        int(req.ServicePort),
+		Hostname:    requestHost(req),
 	})
 	if err != nil {
 		if body != nil {

--- a/internal/agent/origin_routing_test.go
+++ b/internal/agent/origin_routing_test.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pipeops/pipeops-vm-agent/internal/controlplane"
+)
+
+func TestParseDaemonRoutes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want map[string]string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"app.example.com=localhost:3000", map[string]string{"app.example.com": "localhost:3000"}},
+		{
+			"app.example.com=localhost:3000, db.example.com=127.0.0.1:5432",
+			map[string]string{"app.example.com": "localhost:3000", "db.example.com": "127.0.0.1:5432"},
+		},
+		{"bad,=x,y=,ok=localhost:8080", map[string]string{"ok": "localhost:8080"}},
+	}
+	for _, c := range cases {
+		if got := parseDaemonRoutes(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("parseDaemonRoutes(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRequestHost(t *testing.T) {
+	if got := requestHost(nil); got != "" {
+		t.Fatalf("nil req = %q, want empty", got)
+	}
+	req := &controlplane.ProxyRequest{Headers: map[string][]string{"Host": {"app.example.com"}}}
+	if got := requestHost(req); got != "app.example.com" {
+		t.Fatalf("Host header = %q, want app.example.com", got)
+	}
+	req2 := &controlplane.ProxyRequest{Headers: map[string][]string{"X-Forwarded-Host": {"fwd.example.com"}}}
+	if got := requestHost(req2); got != "fwd.example.com" {
+		t.Fatalf("X-Forwarded-Host = %q, want fwd.example.com", got)
+	}
+	if got := requestHost(&controlplane.ProxyRequest{}); got != "" {
+		t.Fatalf("no headers = %q, want empty", got)
+	}
+}

--- a/internal/agent/origin_routing_test.go
+++ b/internal/agent/origin_routing_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pipeops/pipeops-vm-agent/internal/controlplane"
+	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 )
 
 func TestParseDaemonRoutes(t *testing.T) {
@@ -25,6 +26,50 @@ func TestParseDaemonRoutes(t *testing.T) {
 		if got := parseDaemonRoutes(c.in); !reflect.DeepEqual(got, c.want) {
 			t.Fatalf("parseDaemonRoutes(%q) = %v, want %v", c.in, got, c.want)
 		}
+	}
+}
+
+func TestDaemonOriginEnabled(t *testing.T) {
+	t.Setenv("PIPEOPS_ORIGIN_MODE", "")
+	if daemonOriginEnabled(nil) {
+		t.Fatal("nil config + no env should be cluster mode")
+	}
+	if daemonOriginEnabled(&types.Config{}) {
+		t.Fatal("empty config should be cluster mode")
+	}
+	if !daemonOriginEnabled(&types.Config{Daemon: &types.DaemonConfig{Enabled: true}}) {
+		t.Fatal("daemon.enabled should select daemon mode")
+	}
+	t.Setenv("PIPEOPS_ORIGIN_MODE", "host")
+	if !daemonOriginEnabled(&types.Config{}) {
+		t.Fatal("PIPEOPS_ORIGIN_MODE=host should select daemon mode")
+	}
+}
+
+func TestBuildHostDialer_FromConfig(t *testing.T) {
+	t.Setenv("PIPEOPS_DAEMON_ORIGIN", "")
+	t.Setenv("PIPEOPS_DAEMON_ROUTES", "")
+	cfg := &types.Config{Daemon: &types.DaemonConfig{
+		DefaultOrigin: "localhost:3000",
+		Ingress: []types.DaemonIngressRule{
+			{Hostname: "app.example.com", Origin: "localhost:8080"},
+			{Hostname: "", Origin: "skip"},  // skipped: no hostname
+			{Hostname: "skip2", Origin: ""}, // skipped: no origin
+		},
+		AllowedOrigins: []string{"localhost:8080"},
+	}}
+	hd := buildHostDialer(cfg)
+	if hd.DefaultAddress != "localhost:3000" {
+		t.Fatalf("default = %q, want localhost:3000", hd.DefaultAddress)
+	}
+	if got := hd.Routes["app.example.com"]; got != "localhost:8080" {
+		t.Fatalf("route = %q, want localhost:8080", got)
+	}
+	if len(hd.Routes) != 1 {
+		t.Fatalf("routes = %d, want 1 (invalid rules skipped)", len(hd.Routes))
+	}
+	if len(hd.AllowedOrigins) != 1 {
+		t.Fatalf("allowlist = %d, want 1", len(hd.AllowedOrigins))
 	}
 }
 

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pipeops/pipeops-vm-agent/internal/origin"
 	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 	"github.com/sirupsen/logrus"
 )
@@ -33,6 +34,7 @@ type Client struct {
 	logger       *logrus.Logger
 	tlsConfig    *tls.Config // TLS config for reconnecting to gateway
 	timeouts     *types.Timeouts
+	originDialer origin.Dialer // propagated to ws/gateway clients for L4 origin resolution
 
 	// Stored handlers to re-apply on client recreation
 	proxyHandler        func(*ProxyRequest, ProxyResponseWriter)
@@ -40,6 +42,17 @@ type Client struct {
 	onReconnect         func()
 	onWebSocketData     func(string, []byte)
 	onWebSocketClose    func(string)
+}
+
+// SetOriginDialer sets the origin dialer used for L4 (yamux) targets and
+// propagates it to the current websocket client. It is re-applied to any
+// gateway client created during registration/reconnect. nil = in-cluster
+// behaviour (resolve Kubernetes Services via cluster DNS).
+func (c *Client) SetOriginDialer(d origin.Dialer) {
+	c.originDialer = d
+	if c.wsClient != nil {
+		c.wsClient.originDialer = d
+	}
 }
 
 func buildTLSConfig(cfg *types.TLSConfig, logger *logrus.Logger) (*tls.Config, error) {
@@ -212,6 +225,7 @@ func (c *Client) RegisterAgent(ctx context.Context, agent *types.Agent) (*Regist
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gateway WebSocket client: %w", err)
 		}
+		gatewayClient.originDialer = c.originDialer
 
 		// Re-apply handlers to gateway client
 		if c.onRegistrationError != nil {
@@ -271,6 +285,7 @@ func (c *Client) ResumeSession(ctx context.Context, gatewayURL string, clusterUU
 	if err != nil {
 		return fmt.Errorf("failed to create gateway client: %w", err)
 	}
+	gatewayClient.originDialer = c.originDialer
 
 	// Re-apply handlers
 	if c.onRegistrationError != nil {

--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/pipeops/pipeops-vm-agent/internal/origin"
 	"github.com/pipeops/pipeops-vm-agent/internal/tunnel"
 	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ type WebSocketClient struct {
 	logger            *logrus.Logger
 	tlsConfig         *tls.Config
 	timeouts          *types.Timeouts
+	originDialer      origin.Dialer // how L4 yamux streams reach their target (cluster Service vs daemon host:port)
 	conn              *websocket.Conn
 	connMutex         sync.RWMutex
 	writeMutex        sync.Mutex
@@ -2888,6 +2890,9 @@ func (c *WebSocketClient) handleGatewayHello(msg *WebSocketMessage) {
 
 	// Parse yamux configuration
 	config := tunnel.DefaultYamuxConfig()
+	// Daemon mode: route L4 streams through the origin dialer (local host:port).
+	// nil = in-cluster behaviour (resolve the Service via cluster DNS).
+	config.OriginDialer = c.originDialer
 	if yamuxConfig, ok := msg.Payload["yamux_config"].(map[string]interface{}); ok {
 		if windowSize, ok := yamuxConfig["max_stream_window_size"].(float64); ok && windowSize > 0 {
 			config.MaxStreamWindowSize = uint32(windowSize)

--- a/internal/origin/dialer.go
+++ b/internal/origin/dialer.go
@@ -92,6 +92,10 @@ type HostDialer struct {
 	DefaultAddress string
 	// Routes optionally maps a public hostname to a specific local address.
 	Routes map[string]string
+	// AllowedOrigins, when non-empty, restricts which resolved addresses may be
+	// dialed (SSRF guard). Entries are "host:port", bare "host" (any port), or
+	// "unix:///path". Empty = allow any configured address (trusted config).
+	AllowedOrigins []string
 }
 
 // NewHostDialer returns a HostDialer with a default origin address.
@@ -109,14 +113,48 @@ func (d *HostDialer) resolve(t Target) (network, address string, err error) {
 	if addr == "" {
 		return "", "", fmt.Errorf("origin: no local address configured for host %q", t.Hostname)
 	}
-	if strings.HasPrefix(addr, "unix://") {
-		return "unix", strings.TrimPrefix(addr, "unix://"), nil
+	if sock, ok := strings.CutPrefix(addr, "unix://"); ok {
+		network, address = "unix", sock
+	} else {
+		network = t.Protocol
+		if network == "" {
+			network = "tcp"
+		}
+		address = addr
 	}
-	network = t.Protocol
-	if network == "" {
-		network = "tcp"
+	if !d.allowed(network, address) {
+		return "", "", fmt.Errorf("origin: address %q not permitted by daemon allowed_origins (host %q)", address, t.Hostname)
 	}
-	return network, addr, nil
+	return network, address, nil
+}
+
+// allowed reports whether the resolved address passes the SSRF allowlist. An
+// empty allowlist permits everything (the operator is trusted to configure
+// origins); a non-empty allowlist requires an exact "host:port"/"unix:///path"
+// match, or a bare "host" entry matching the address's host (any port).
+func (d *HostDialer) allowed(network, address string) bool {
+	if len(d.AllowedOrigins) == 0 {
+		return true
+	}
+	for _, a := range d.AllowedOrigins {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if network == "unix" {
+			if a == address || strings.TrimPrefix(a, "unix://") == address {
+				return true
+			}
+			continue
+		}
+		if a == address {
+			return true
+		}
+		if host, _, err := net.SplitHostPort(address); err == nil && host == a {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *HostDialer) HTTPHostPort(t Target) (string, error) {

--- a/internal/origin/dialer.go
+++ b/internal/origin/dialer.go
@@ -1,0 +1,137 @@
+// Package origin abstracts "where the connector forwards a tunneled request to"
+// so the same agent can run either in-cluster (dialing Kubernetes Services via
+// cluster DNS) or as a host daemon (dialing localhost / host:port / unix
+// sockets), without the proxy/tunnel hot paths knowing which mode they're in.
+//
+// It is intentionally dependency-free (no agent/tunnel/controlplane imports) so
+// every layer can import it without creating an import cycle.
+package origin
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Target identifies the origin a tunneled request should reach.
+//
+//   - In Kubernetes mode the gateway sends ServiceName/Namespace/Port (and the
+//     ClusterDialer resolves them to <svc>.<ns>.svc.<clusterDomain>).
+//   - In daemon mode the HostDialer maps the request to a configured local
+//     address (host:port or unix socket), keyed by Hostname (and, later, by a
+//     full route table).
+type Target struct {
+	Protocol    string // "tcp" | "udp" — for L4 dials; empty for HTTP
+	ServiceName string
+	Namespace   string
+	Port        int
+	Hostname    string // public host the request arrived for (daemon route key)
+}
+
+// Dialer resolves and connects to a Target.
+type Dialer interface {
+	// HTTPHostPort returns the "host:port" the HTTP proxy path should dial.
+	HTTPHostPort(t Target) (string, error)
+	// DialContext opens an L4 (tcp/udp) connection to the Target.
+	DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error)
+}
+
+// ClusterDialer is the in-cluster behaviour: resolve Kubernetes Services through
+// cluster DNS (<service>.<namespace>.svc.<clusterDomain>). It preserves the
+// exact addressing the agent used before the origin abstraction existed.
+type ClusterDialer struct {
+	// ClusterDomain is the cluster DNS suffix, e.g. "cluster.local".
+	ClusterDomain string
+}
+
+// NewClusterDialer returns a ClusterDialer; clusterDomain defaults to
+// "cluster.local" when empty.
+func NewClusterDialer(clusterDomain string) *ClusterDialer {
+	if clusterDomain == "" {
+		clusterDomain = "cluster.local"
+	}
+	return &ClusterDialer{ClusterDomain: clusterDomain}
+}
+
+func (d *ClusterDialer) fqdn(t Target) (string, error) {
+	if t.ServiceName == "" || t.Namespace == "" {
+		return "", fmt.Errorf("origin: service name and namespace are required in cluster mode")
+	}
+	return fmt.Sprintf("%s.%s.svc.%s", t.ServiceName, t.Namespace, d.ClusterDomain), nil
+}
+
+func (d *ClusterDialer) HTTPHostPort(t Target) (string, error) {
+	host, err := d.fqdn(t)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s:%d", host, t.Port), nil
+}
+
+func (d *ClusterDialer) DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error) {
+	host, err := d.fqdn(t)
+	if err != nil {
+		return nil, err
+	}
+	proto := t.Protocol
+	if proto == "" {
+		proto = "tcp"
+	}
+	dialer := net.Dialer{Timeout: timeout}
+	return dialer.DialContext(ctx, proto, fmt.Sprintf("%s:%d", host, t.Port))
+}
+
+// HostDialer is the daemon behaviour: forward to local origins. For the Phase-0
+// spike it resolves every Target to a single configured address; a later phase
+// swaps in a full route table (hostname/service -> origin address).
+type HostDialer struct {
+	// DefaultAddress is the fallback origin, e.g. "localhost:3000" or
+	// "unix:///run/app.sock".
+	DefaultAddress string
+	// Routes optionally maps a public hostname to a specific local address.
+	Routes map[string]string
+}
+
+// NewHostDialer returns a HostDialer with a default origin address.
+func NewHostDialer(defaultAddress string, routes map[string]string) *HostDialer {
+	return &HostDialer{DefaultAddress: defaultAddress, Routes: routes}
+}
+
+func (d *HostDialer) resolve(t Target) (network, address string, err error) {
+	addr := d.DefaultAddress
+	if d.Routes != nil && t.Hostname != "" {
+		if a, ok := d.Routes[t.Hostname]; ok {
+			addr = a
+		}
+	}
+	if addr == "" {
+		return "", "", fmt.Errorf("origin: no local address configured for host %q", t.Hostname)
+	}
+	if strings.HasPrefix(addr, "unix://") {
+		return "unix", strings.TrimPrefix(addr, "unix://"), nil
+	}
+	network = t.Protocol
+	if network == "" {
+		network = "tcp"
+	}
+	return network, addr, nil
+}
+
+func (d *HostDialer) HTTPHostPort(t Target) (string, error) {
+	_, addr, err := d.resolve(t)
+	if err != nil {
+		return "", err
+	}
+	return addr, nil
+}
+
+func (d *HostDialer) DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error) {
+	network, addr, err := d.resolve(t)
+	if err != nil {
+		return nil, err
+	}
+	dialer := net.Dialer{Timeout: timeout}
+	return dialer.DialContext(ctx, network, addr)
+}

--- a/internal/origin/dialer_test.go
+++ b/internal/origin/dialer_test.go
@@ -83,6 +83,33 @@ func TestHostDialer_EndToEnd(t *testing.T) {
 	}
 }
 
+func TestHostDialer_Allowlist(t *testing.T) {
+	d := NewHostDialer("localhost:3000", map[string]string{
+		"ok.example.com":  "127.0.0.1:8080",
+		"bad.example.com": "10.0.0.5:9000",
+	})
+	d.AllowedOrigins = []string{"127.0.0.1:8080", "localhost"} // exact addr + bare host
+
+	// Allowed: exact host:port match.
+	if _, err := d.HTTPHostPort(Target{Hostname: "ok.example.com"}); err != nil {
+		t.Fatalf("expected ok.example.com allowed, got %v", err)
+	}
+	// Allowed: bare-host entry matches default localhost:3000.
+	if _, err := d.HTTPHostPort(Target{Hostname: "unknown"}); err != nil {
+		t.Fatalf("expected default localhost allowed, got %v", err)
+	}
+	// Blocked: not in allowlist.
+	if _, err := d.HTTPHostPort(Target{Hostname: "bad.example.com"}); err == nil {
+		t.Fatal("expected bad.example.com to be blocked by allowlist")
+	}
+
+	// Empty allowlist allows everything.
+	open := NewHostDialer("localhost:3000", map[string]string{"x": "10.0.0.5:9000"})
+	if _, err := open.HTTPHostPort(Target{Hostname: "x"}); err != nil {
+		t.Fatalf("empty allowlist should permit any address, got %v", err)
+	}
+}
+
 var _ Dialer = (*ClusterDialer)(nil)
 var _ Dialer = (*HostDialer)(nil)
 var _ net.Conn = nil

--- a/internal/origin/dialer_test.go
+++ b/internal/origin/dialer_test.go
@@ -1,0 +1,88 @@
+package origin
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClusterDialer_HTTPHostPort(t *testing.T) {
+	d := NewClusterDialer("") // default cluster.local
+	got, err := d.HTTPHostPort(Target{ServiceName: "api", Namespace: "default", Port: 8080})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "api.default.svc.cluster.local:8080"; got != want {
+		t.Fatalf("HTTPHostPort = %q, want %q", got, want)
+	}
+
+	d2 := NewClusterDialer("k8s.internal")
+	got2, _ := d2.HTTPHostPort(Target{ServiceName: "web", Namespace: "prod", Port: 80})
+	if want := "web.prod.svc.k8s.internal:80"; got2 != want {
+		t.Fatalf("custom domain = %q, want %q", got2, want)
+	}
+
+	if _, err := d.HTTPHostPort(Target{ServiceName: "", Namespace: "default", Port: 80}); err == nil {
+		t.Fatal("expected error for missing service name")
+	}
+}
+
+func TestHostDialer_HTTPHostPort(t *testing.T) {
+	d := NewHostDialer("localhost:3000", map[string]string{"db.example.com": "127.0.0.1:5432"})
+
+	// Falls back to default when hostname isn't in the route table.
+	if got, _ := d.HTTPHostPort(Target{Hostname: "app.example.com"}); got != "localhost:3000" {
+		t.Fatalf("default = %q, want localhost:3000", got)
+	}
+	// Uses the per-host route when present.
+	if got, _ := d.HTTPHostPort(Target{Hostname: "db.example.com"}); got != "127.0.0.1:5432" {
+		t.Fatalf("routed = %q, want 127.0.0.1:5432", got)
+	}
+	// No default and no match -> error.
+	empty := NewHostDialer("", nil)
+	if _, err := empty.HTTPHostPort(Target{Hostname: "x"}); err == nil {
+		t.Fatal("expected error when no origin configured")
+	}
+}
+
+// TestHostDialer_EndToEnd proves the daemon path works with NO Kubernetes: a
+// real local HTTP server is reached purely via the HostDialer-resolved address.
+func TestHostDialer_EndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("from local origin"))
+	}))
+	defer srv.Close()
+
+	// srv.URL is like http://127.0.0.1:PORT — strip the scheme for the dialer.
+	addr := srv.Listener.Addr().String()
+	d := NewHostDialer(addr, nil)
+
+	hostport, err := d.HTTPHostPort(Target{Hostname: "anything"})
+	if err != nil {
+		t.Fatalf("HTTPHostPort: %v", err)
+	}
+
+	// Dial it the way the proxy path would.
+	conn, err := d.DialContext(context.Background(), Target{Hostname: "anything"}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	_ = conn.Close()
+
+	resp, err := http.Get("http://" + hostport + "/")
+	if err != nil {
+		t.Fatalf("GET via host dialer: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTeapot {
+		t.Fatalf("status = %d, want 418 (proves request reached the local origin)", resp.StatusCode)
+	}
+}
+
+var _ Dialer = (*ClusterDialer)(nil)
+var _ Dialer = (*HostDialer)(nil)
+var _ net.Conn = nil

--- a/internal/tunnel/yamux_client.go
+++ b/internal/tunnel/yamux_client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/yamux"
+	"github.com/pipeops/pipeops-vm-agent/internal/origin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
@@ -61,6 +62,10 @@ type YamuxConfig struct {
 	KeepAliveInterval   time.Duration
 	ConnectionTimeout   time.Duration
 	AcceptBacklog       int
+	// OriginDialer, when set, decides how to reach the target (e.g. daemon mode
+	// dialing a local host:port). When nil, the in-cluster behaviour is used
+	// (resolve the Kubernetes Service via cluster DNS).
+	OriginDialer origin.Dialer
 }
 
 // DefaultYamuxConfig returns default yamux configuration
@@ -186,17 +191,29 @@ func (c *YamuxTunnelClient) handleStream(stream *yamux.Stream) {
 
 	logger.Debug("[YAMUX] Received tunnel stream")
 
-	// Dial target service
-	target := fmt.Sprintf("%s.%s.svc.cluster.local:%d",
-		header.ServiceName, header.ServiceNamespace, header.ServicePort)
+	// Dial target service.
+	proto := "tcp"
+	if header.Protocol == TunnelProtocolUDP {
+		proto = "udp"
+	}
+	target := fmt.Sprintf("%s.%s:%d/%s", header.ServiceName, header.ServiceNamespace, header.ServicePort, proto)
 
 	var targetConn net.Conn
 	var err error
-
-	if header.Protocol == TunnelProtocolUDP {
-		targetConn, err = net.DialTimeout("udp", target, c.config.ConnectionTimeout)
+	if c.config.OriginDialer != nil {
+		// Daemon/host mode: the dialer maps the target metadata to a real local
+		// address (host:port, unix socket, ...). No Kubernetes resolution.
+		targetConn, err = c.config.OriginDialer.DialContext(context.Background(), origin.Target{
+			Protocol:    proto,
+			ServiceName: header.ServiceName,
+			Namespace:   header.ServiceNamespace,
+			Port:        int(header.ServicePort),
+		}, c.config.ConnectionTimeout)
 	} else {
-		targetConn, err = net.DialTimeout("tcp", target, c.config.ConnectionTimeout)
+		// In-cluster: resolve the Kubernetes Service via cluster DNS.
+		target = fmt.Sprintf("%s.%s.svc.cluster.local:%d",
+			header.ServiceName, header.ServiceNamespace, header.ServicePort)
+		targetConn, err = net.DialTimeout(proto, target, c.config.ConnectionTimeout)
 	}
 
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -300,6 +300,26 @@ type Config struct {
 	Upgrade    *UpgradeConfig           `yaml:"upgrade,omitempty" mapstructure:"upgrade"`       // K3s automated upgrade configuration
 	Encryption *SecretsEncryptionConfig `yaml:"encryption,omitempty" mapstructure:"encryption"` // K3s secrets encryption configuration
 	Timeouts   *Timeouts                `yaml:"timeouts" mapstructure:"timeouts"`
+	Daemon     *DaemonConfig            `yaml:"daemon,omitempty" mapstructure:"daemon"` // Host-daemon mode (forward to local origins, no Kubernetes)
+}
+
+// DaemonConfig configures the connector to run as a host daemon (cloudflared-style):
+// instead of resolving Kubernetes Services via cluster DNS, tunneled requests are
+// forwarded to local origins (host:port / unix socket). When Enabled is false the
+// agent uses normal in-cluster origin resolution.
+type DaemonConfig struct {
+	Enabled       bool                `yaml:"enabled" mapstructure:"enabled"`
+	DefaultOrigin string              `yaml:"default_origin" mapstructure:"default_origin"` // fallback local origin, e.g. "localhost:3000"
+	Ingress       []DaemonIngressRule `yaml:"ingress" mapstructure:"ingress"`               // per-hostname routes (cloudflared-style)
+	// AllowedOrigins, when non-empty, restricts which local addresses the daemon
+	// may dial (SSRF guard). Entries are "host:port", bare "host", or "unix:/path".
+	AllowedOrigins []string `yaml:"allowed_origins" mapstructure:"allowed_origins"`
+}
+
+// DaemonIngressRule maps a public hostname to a local origin address.
+type DaemonIngressRule struct {
+	Hostname string `yaml:"hostname" mapstructure:"hostname"`
+	Origin   string `yaml:"origin" mapstructure:"origin"` // "localhost:3000", "unix:///run/app.sock"
 }
 
 // AgentConfig represents agent-specific configuration


### PR DESCRIPTION
Lets the connector run as a **host daemon** (cloudflared-style): forward tunneled traffic — HTTP and L4 TCP/UDP — to **local origins with no Kubernetes**, behind a single `origin.Dialer` seam. Opt-in; in-cluster behaviour is unchanged. Full design: `docs/daemon-mode-design.md`; copy-paste config: `examples/daemon-config.yaml`.

## Why
The agent only ever dialed Kubernetes Services via cluster DNS (`*.svc.cluster.local`). Everything else (outbound tunnel, registration, reconnect, request_id mux, yamux L4) is already origin-agnostic, so the k8s coupling is concentrated in *where requests are dialed*. This abstracts that one seam.

## What ships
**Phase 0 — origin seam**
- `internal/origin`: `Dialer` + `ClusterDialer` (current behaviour) + `HostDialer` (daemon). Tests incl. an end-to-end test reaching a real local HTTP server with zero k8s.
- HTTP path (`agent.proxyToService`) resolves origins via the dialer.

**Phase 1 — L4 + per-host routing**
- Dialer threaded to the yamux L4 path (`agent → controlplane.Client → WebSocketClient → YamuxConfig`), re-applied across register/reconnect. Daemon mode now covers HTTP **and** TCP/UDP.
- HTTP path passes the request `Host` (/`X-Forwarded-Host`) as the per-host route key.

**Phase 2 — config + guard**
- `daemon:` config section — `enabled`, `default_origin`, `ingress[]` (hostname → origin), `allowed_origins[]`.
- `--daemon` / `--daemon-default-origin` flags; `PIPEOPS_DAEMON_ENABLED` / `PIPEOPS_DAEMON_ORIGIN` / `PIPEOPS_DAEMON_ROUTES` env. `PIPEOPS_ORIGIN_MODE=host` kept as a back-compat alias.
- **SSRF allowlist** on `HostDialer`: when non-empty, only listed addresses may be dialed (exact `host:port`, bare `host`, or `unix:///path`). Empty = trusted-config.

## Safety
Default everywhere is `ClusterDialer` → **in-cluster behaviour unchanged**; daemon is opt-in. One intentional consistency fix: the L4 path now uses the *detected* cluster DNS domain (matching the HTTP path) instead of a hardcoded `cluster.local`. `go build ./...`, `go vet`, and `go test ./internal/{origin,agent,tunnel,controlplane}` pass.

## Remaining (Phase 2 tail / Phase 3)
- Config-file **hot reload** of `ingress:` rules.
- Local credentials/state (`FileStore`) so a daemon needs no kubeconfig at all.
- A real **slim build** dropping `client-go` via a build tag + packaging (systemd/Docker, `pipeops tunnel run` UX).

Note: builds in module mode (`-mod=mod`); repo has a gitignored local vendor dir, CI is module-mode.