### PR TITLE
feat(agent): daemon config hot-reload + thread-safe HostDialer

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/pipeops/pipeops-vm-agent/internal/agent"
 	"github.com/pipeops/pipeops-vm-agent/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -321,6 +322,21 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	agentInstance, err := agent.New(config, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create agent: %w", err)
+	}
+
+	// In daemon mode, hot-reload the origin route table when the config file
+	// changes — no restart needed to add/remove ingress rules.
+	if config.Daemon != nil && config.Daemon.Enabled {
+		viper.OnConfigChange(func(e fsnotify.Event) {
+			newCfg := &types.Config{}
+			if uerr := viper.Unmarshal(newCfg); uerr != nil {
+				logger.WithError(uerr).Warn("Config reload: unmarshal failed, keeping previous daemon routes")
+				return
+			}
+			logger.WithField("file", e.Name).Info("Config changed — reloading daemon routes")
+			agentInstance.ReloadDaemonConfig(newCfg)
+		})
+		viper.WatchConfig()
 	}
 
 	// Setup signal handling for graceful shutdown

--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -162,11 +162,14 @@ ingress:
 - **Phase 1 — done.** `OriginDialer` threaded to the L4 yamux path
   (`agent → controlplane.Client → WebSocketClient → YamuxConfig`); per-host routing from the request
   `Host`; multi-route `HostDialer`.
-- **Phase 2 — partial.** Config-driven routes shipped: a `daemon:` config section
+- **Phase 2 — done.** Config-driven routes: a `daemon:` config section
   (`enabled`/`default_origin`/`ingress`/`allowed_origins`), a `--daemon` flag, `PIPEOPS_DAEMON_*`
-  env, and an SSRF allowlist on `HostDialer`. See `examples/daemon-config.yaml`.
-  **Remaining:** config-file hot reload, local `FileStore` credentials/state, a slim build that drops
-  client-go via a build tag.
+  env, an SSRF allowlist on `HostDialer`, and **config-file hot reload** (`viper.WatchConfig` →
+  `Agent.ReloadDaemonConfig` → `HostDialer.Update`, a concurrency-safe atomic swap of the route
+  table — no restart to add/remove ingress rules). See `examples/daemon-config.yaml`.
+- **Phase 3 — remaining.** Local `FileStore` credentials/state (so a daemon needs no kubeconfig at
+  all), a slim build that drops client-go via a build tag, and packaging (systemd/Docker,
+  `pipeops tunnel run` UX).
 
 ### Configuration (shipped)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pipeops/pipeops-vm-agent
 go 1.25.0
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/yamux v0.1.2
@@ -50,7 +51,6 @@ require (
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -527,6 +527,24 @@ func requestHost(req *controlplane.ProxyRequest) string {
 	return ""
 }
 
+// ReloadDaemonConfig applies an updated daemon configuration to the running host
+// dialer (config hot-reload). It is a no-op when not in daemon mode. Safe to
+// call concurrently with request serving — HostDialer.Update swaps the route
+// table atomically.
+func (a *Agent) ReloadDaemonConfig(config *types.Config) {
+	hd, ok := a.originDialer.(*origin.HostDialer)
+	if !ok {
+		return // not in daemon mode; nothing to reload
+	}
+	next := buildHostDialer(config)
+	hd.Update(next.DefaultAddress, next.Routes, next.AllowedOrigins)
+	a.logger.WithFields(logrus.Fields{
+		"default_origin": next.DefaultAddress,
+		"routes":         len(next.Routes),
+		"allowlist":      len(next.AllowedOrigins),
+	}).Info("Daemon origin routes reloaded from config")
+}
+
 // daemonOriginEnabled reports whether the connector should run in host-daemon
 // mode (forward to local origins) rather than resolving Kubernetes Services.
 // Config `daemon.enabled` takes precedence; PIPEOPS_ORIGIN_MODE=host is the

--- a/internal/origin/dialer.go
+++ b/internal/origin/dialer.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -83,10 +84,14 @@ func (d *ClusterDialer) DialContext(ctx context.Context, t Target, timeout time.
 	return dialer.DialContext(ctx, proto, fmt.Sprintf("%s:%d", host, t.Port))
 }
 
-// HostDialer is the daemon behaviour: forward to local origins. For the Phase-0
-// spike it resolves every Target to a single configured address; a later phase
-// swaps in a full route table (hostname/service -> origin address).
+// HostDialer is the daemon behaviour: forward to local origins, resolving each
+// Target to a configured local address (per-host route table + a default).
+//
+// It is safe for concurrent use: serve goroutines read the route table while a
+// config reload swaps it via Update. Reads snapshot under an RLock; Update
+// replaces (never mutates) the table/allowlist under a write lock.
 type HostDialer struct {
+	mu sync.RWMutex
 	// DefaultAddress is the fallback origin, e.g. "localhost:3000" or
 	// "unix:///run/app.sock".
 	DefaultAddress string
@@ -103,13 +108,28 @@ func NewHostDialer(defaultAddress string, routes map[string]string) *HostDialer 
 	return &HostDialer{DefaultAddress: defaultAddress, Routes: routes}
 }
 
+// Update atomically replaces the default origin, route table, and allowlist.
+// Used by config hot-reload. The provided maps/slices are taken as-is (the
+// caller must not mutate them afterwards).
+func (d *HostDialer) Update(defaultAddress string, routes map[string]string, allowed []string) {
+	d.mu.Lock()
+	d.DefaultAddress = defaultAddress
+	d.Routes = routes
+	d.AllowedOrigins = allowed
+	d.mu.Unlock()
+}
+
 func (d *HostDialer) resolve(t Target) (network, address string, err error) {
+	d.mu.RLock()
 	addr := d.DefaultAddress
 	if d.Routes != nil && t.Hostname != "" {
 		if a, ok := d.Routes[t.Hostname]; ok {
 			addr = a
 		}
 	}
+	allowlist := d.AllowedOrigins // slice header copy; Update replaces, never mutates
+	d.mu.RUnlock()
+
 	if addr == "" {
 		return "", "", fmt.Errorf("origin: no local address configured for host %q", t.Hostname)
 	}
@@ -122,21 +142,21 @@ func (d *HostDialer) resolve(t Target) (network, address string, err error) {
 		}
 		address = addr
 	}
-	if !d.allowed(network, address) {
+	if !addrAllowed(allowlist, network, address) {
 		return "", "", fmt.Errorf("origin: address %q not permitted by daemon allowed_origins (host %q)", address, t.Hostname)
 	}
 	return network, address, nil
 }
 
-// allowed reports whether the resolved address passes the SSRF allowlist. An
+// addrAllowed reports whether the resolved address passes the SSRF allowlist. An
 // empty allowlist permits everything (the operator is trusted to configure
 // origins); a non-empty allowlist requires an exact "host:port"/"unix:///path"
 // match, or a bare "host" entry matching the address's host (any port).
-func (d *HostDialer) allowed(network, address string) bool {
-	if len(d.AllowedOrigins) == 0 {
+func addrAllowed(allowlist []string, network, address string) bool {
+	if len(allowlist) == 0 {
 		return true
 	}
-	for _, a := range d.AllowedOrigins {
+	for _, a := range allowlist {
 		a = strings.TrimSpace(a)
 		if a == "" {
 			continue

--- a/internal/origin/dialer_test.go
+++ b/internal/origin/dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 )
@@ -108,6 +109,50 @@ func TestHostDialer_Allowlist(t *testing.T) {
 	if _, err := open.HTTPHostPort(Target{Hostname: "x"}); err != nil {
 		t.Fatalf("empty allowlist should permit any address, got %v", err)
 	}
+}
+
+func TestHostDialer_Update(t *testing.T) {
+	d := NewHostDialer("localhost:3000", map[string]string{"a.example.com": "localhost:8080"})
+	if got, _ := d.HTTPHostPort(Target{Hostname: "a.example.com"}); got != "localhost:8080" {
+		t.Fatalf("pre-reload = %q", got)
+	}
+	// Hot-reload: new route table + default + allowlist.
+	d.Update("localhost:4000", map[string]string{"b.example.com": "localhost:9090"}, []string{"localhost:9090"})
+	if got, _ := d.HTTPHostPort(Target{Hostname: "b.example.com"}); got != "localhost:9090" {
+		t.Fatalf("post-reload route = %q, want localhost:9090", got)
+	}
+	// Old route is gone; default falls through but allowlist now blocks it.
+	if _, err := d.HTTPHostPort(Target{Hostname: "a.example.com"}); err == nil {
+		t.Fatal("expected old route to fall to default and be blocked by new allowlist")
+	}
+}
+
+// TestHostDialer_ConcurrentReload exercises Update racing with reads; run with
+// -race to catch unsynchronized access to the route table.
+func TestHostDialer_ConcurrentReload(t *testing.T) {
+	d := NewHostDialer("localhost:3000", map[string]string{"x": "localhost:1000"})
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = d.HTTPHostPort(Target{Hostname: "x"})
+				}
+			}
+		}()
+	}
+	for i := 0; i < 200; i++ {
+		d.Update("localhost:3000", map[string]string{"x": "localhost:1000"}, []string{"localhost:1000"})
+	}
+	close(stop)
+	wg.Wait()
 }
 
 var _ Dialer = (*ClusterDialer)(nil)


### PR DESCRIPTION
Stacked on #151. Adds **config-file hot reload** for daemon mode so ingress routes can be added/removed without restarting the connector — and makes `HostDialer` concurrency-safe (a hard requirement once reload races with request serving).

## What
- **`HostDialer` is now concurrency-safe.** An `RWMutex` guards the route table; reads snapshot under `RLock`; `HostDialer.Update(default, routes, allowlist)` atomically swaps all three under a write lock. The allowlist check is refactored into a pure `addrAllowed()` over the snapshot. Includes a `-race` test that hammers `Update` against concurrent reads.
- **`Agent.ReloadDaemonConfig(cfg)`** rebuilds the host dialer from a fresh config and applies it via `Update`; no-op when not in daemon mode.
- **`cmd/agent`**: in daemon mode, `viper.WatchConfig` + `OnConfigChange` re-unmarshals the config file and calls `ReloadDaemonConfig`. Edit `ingress:` in `~/.pipeops-agent.yaml` → routes update live.
- `fsnotify` promoted to a direct dep (was already indirect via viper; `go.sum` unchanged).

## Safety
Only active in daemon mode; cluster mode and the non-daemon path are untouched. The mutex closes a real data race that hot reload would otherwise introduce. `go build ./...`, `go vet`, `go test -race ./internal/origin`, and `go test ./internal/{agent,controlplane,tunnel}` all pass.

## Remaining (Phase 3)
- Local `FileStore` credentials/state (daemon needs no kubeconfig at all).
- Slim build dropping client-go via a build tag + packaging (systemd/Docker, `pipeops tunnel run`).

> Review #151 first — this builds on its `origin.HostDialer`. Once #151 merges, rebase this onto the default branch.