### PR TITLE
feat(agent): file-backed state for daemon mode (no Kubernetes)

### DIFF
--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -167,8 +167,12 @@ ingress:
   env, an SSRF allowlist on `HostDialer`, and **config-file hot reload** (`viper.WatchConfig` →
   `Agent.ReloadDaemonConfig` → `HostDialer.Update`, a concurrency-safe atomic swap of the route
   table — no restart to add/remove ingress rules). See `examples/daemon-config.yaml`.
-- **Phase 3 — remaining.** Local `FileStore` credentials/state (so a daemon needs no kubeconfig at
-  all), a slim build that drops client-go via a build tag, and packaging (systemd/Docker,
+- **Phase 3 — partial.** Local file-backed state shipped: in daemon mode `StateManager` persists
+  identity/state (agent id, cluster token, gateway URL) to a local file (default
+  `$HOME/.pipeops-agent/state.yaml`, written 0600, atomic temp+rename) instead of a ConfigMap/Secret,
+  reusing the existing token — so a daemon survives restarts with no Kubernetes. Configure via
+  `daemon.state_file` or `PIPEOPS_STATE_FILE`.
+  **Remaining:** a slim build that drops client-go via a build tag, and packaging (systemd/Docker,
   `pipeops tunnel run` UX).
 
 ### Configuration (shipped)

--- a/examples/daemon-config.yaml
+++ b/examples/daemon-config.yaml
@@ -16,6 +16,10 @@ agent:
 daemon:
   enabled: true
 
+  # Where the daemon persists its identity/state (agent id, cluster token,
+  # gateway URL) across restarts. Written 0600. Default: $HOME/.pipeops-agent/state.yaml.
+  state_file: "/var/lib/pipeops-agent/state.yaml"
+
   # Fallback origin used for any hostname not matched by an ingress rule below.
   default_origin: "localhost:3000"
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -208,8 +208,19 @@ type Agent struct {
 func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Initialize state manager for optional persistence
-	stateManager := state.NewStateManager()
+	// Initialize state manager for persistence. In daemon mode there is no
+	// Kubernetes, so persist identity/state to a local file (reusing the existing
+	// token); otherwise use the ConfigMap/Secret-backed manager.
+	var stateManager *state.StateManager
+	if daemonOriginEnabled(config) {
+		statePath := ""
+		if config.Daemon != nil {
+			statePath = config.Daemon.StateFile
+		}
+		stateManager = state.NewStateManagerWithFile(statePath)
+	} else {
+		stateManager = state.NewStateManager()
+	}
 	logger.WithField("state_path", stateManager.GetStatePath()).Debug("Initialized state manager for optional persistence")
 
 	agent := &Agent{

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -14,17 +15,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 )
 
 var logger = logrus.WithField("component", "StateManager")
 
 // AgentState represents the persistent state of the agent
 type AgentState struct {
-	AgentID         string `yaml:"agent_id"`
-	ClusterID       string `yaml:"cluster_id"`
-	ClusterToken    string `yaml:"cluster_token"`
-	ClusterCertData string `yaml:"cluster_cert_data"`
-	GatewayWSURL    string `yaml:"gateway_ws_url"`
+	AgentID         string `yaml:"agent_id" json:"agent_id"`
+	ClusterID       string `yaml:"cluster_id" json:"cluster_id"`
+	ClusterToken    string `yaml:"cluster_token" json:"cluster_token"`
+	ClusterCertData string `yaml:"cluster_cert_data" json:"cluster_cert_data"`
+	GatewayWSURL    string `yaml:"gateway_ws_url" json:"gateway_ws_url"`
 }
 
 // StateManager manages persistent agent state using Kubernetes ConfigMap for non-sensitive data
@@ -34,6 +36,8 @@ type StateManager struct {
 	state         AgentState
 	statePath     string
 	useConfigMap  bool
+	useFileStore  bool   // daemon mode: persist to a local file instead of ConfigMap/Secret
+	fileStorePath string // path to the local state file when useFileStore is true
 	namespace     string
 	configMapName string
 	secretName    string
@@ -100,6 +104,78 @@ func NewStateManager() *StateManager {
 	return sm
 }
 
+// NewStateManagerWithFile creates a state manager that persists to a local file
+// (daemon mode — no Kubernetes). The file holds the full state including the
+// cluster token, so it is written 0600. An empty path defaults to
+// PIPEOPS_STATE_FILE, then $HOME/.pipeops-agent/state.yaml.
+func NewStateManagerWithFile(path string) *StateManager {
+	if path == "" {
+		path = defaultStateFilePath()
+	}
+	sm := &StateManager{
+		useConfigMap:  false,
+		useFileStore:  true,
+		fileStorePath: path,
+	}
+	sm.mu = sync.Mutex{}
+	logger.WithField("path", path).Info("✅ Using local file for state persistence (daemon mode)")
+	return sm
+}
+
+// defaultStateFilePath resolves the daemon state file location.
+func defaultStateFilePath() string {
+	if p := os.Getenv("PIPEOPS_STATE_FILE"); p != "" {
+		return p
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".pipeops-agent", "state.yaml")
+	}
+	return "/var/lib/pipeops-agent/state.yaml"
+}
+
+// loadFromFile reads daemon state from the local file. A missing file yields an
+// empty state (first run).
+func (sm *StateManager) loadFromFile() (*AgentState, error) {
+	data, err := os.ReadFile(sm.fileStorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debug("State file not found (will be created on first save)")
+			return &AgentState{}, nil
+		}
+		return nil, fmt.Errorf("failed to read state file %s: %w", sm.fileStorePath, err)
+	}
+	state := &AgentState{}
+	if len(data) > 0 {
+		if err := yaml.Unmarshal(data, state); err != nil {
+			return nil, fmt.Errorf("failed to parse state file %s: %w", sm.fileStorePath, err)
+		}
+	}
+	sm.updateCache(state)
+	return state, nil
+}
+
+// saveToFile writes daemon state atomically (temp file + rename) with 0600
+// permissions, since it contains the cluster token.
+func (sm *StateManager) saveToFile(state *AgentState) error {
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+	dir := filepath.Dir(sm.fileStorePath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create state dir %s: %w", dir, err)
+	}
+	tmp := sm.fileStorePath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+	if err := os.Rename(tmp, sm.fileStorePath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to commit state file: %w", err)
+	}
+	return nil
+}
+
 // getNamespace returns the namespace the agent is running in
 func getNamespace() string {
 	// First check explicit state namespace environment variable
@@ -122,6 +198,10 @@ func getNamespace() string {
 func (sm *StateManager) Load() (*AgentState, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+
+	if sm.useFileStore {
+		return sm.loadFromFile()
+	}
 
 	if !sm.useConfigMap {
 		logger.Debug("ConfigMap not available, returning empty state")
@@ -181,6 +261,14 @@ func (sm *StateManager) Load() (*AgentState, error) {
 func (sm *StateManager) Save(state *AgentState) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+
+	if sm.useFileStore {
+		if err := sm.saveToFile(state); err != nil {
+			return err
+		}
+		sm.updateCache(state)
+		return nil
+	}
 
 	if !sm.useConfigMap {
 		// Silently skip if ConfigMap not available (state will be in-memory only)
@@ -412,6 +500,9 @@ func (sm *StateManager) SaveGatewayWSURL(url string) error {
 
 // GetStatePath returns info about state storage location
 func (sm *StateManager) GetStatePath() string {
+	if sm.useFileStore {
+		return fmt.Sprintf("file:%s", sm.fileStorePath)
+	}
 	if sm.useConfigMap {
 		return fmt.Sprintf("ConfigMap:%s/%s, Secret:%s/%s", sm.namespace, sm.configMapName, sm.namespace, sm.secretName)
 	}
@@ -420,6 +511,14 @@ func (sm *StateManager) GetStatePath() string {
 
 // Clear removes the state ConfigMap and Secret
 func (sm *StateManager) Clear() error {
+	if sm.useFileStore {
+		if err := os.Remove(sm.fileStorePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove state file %s: %w", sm.fileStorePath, err)
+		}
+		sm.updateCache(&AgentState{})
+		return nil
+	}
+
 	if !sm.useConfigMap {
 		// Nothing to clear for in-memory state
 		return nil

--- a/pkg/state/state_file_test.go
+++ b/pkg/state/state_file_test.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileStore_RoundTripAndPersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "state.yaml")
+
+	sm := NewStateManagerWithFile(path)
+	if !sm.useFileStore || sm.useConfigMap {
+		t.Fatal("expected file-store mode, not configmap")
+	}
+	if got := sm.GetStatePath(); got != "file:"+path {
+		t.Fatalf("GetStatePath = %q", got)
+	}
+
+	// First run: empty.
+	if _, err := sm.GetAgentID(); err == nil {
+		t.Fatal("expected no agent id on first run")
+	}
+
+	// Persist identity + sensitive token.
+	if err := sm.SaveAgentID("agent-123"); err != nil {
+		t.Fatalf("SaveAgentID: %v", err)
+	}
+	if err := sm.SaveClusterToken("secret-token"); err != nil {
+		t.Fatalf("SaveClusterToken: %v", err)
+	}
+	if err := sm.SaveClusterID("cluster-xyz"); err != nil {
+		t.Fatalf("SaveClusterID: %v", err)
+	}
+
+	// Simulate a restart: a fresh manager over the same file must see the state.
+	sm2 := NewStateManagerWithFile(path)
+	if id, err := sm2.GetAgentID(); err != nil || id != "agent-123" {
+		t.Fatalf("GetAgentID after restart = %q, %v", id, err)
+	}
+	if tok, err := sm2.GetClusterToken(); err != nil || tok != "secret-token" {
+		t.Fatalf("GetClusterToken after restart = %q, %v", tok, err)
+	}
+	if cid, err := sm2.GetClusterID(); err != nil || cid != "cluster-xyz" {
+		t.Fatalf("GetClusterID after restart = %q, %v", cid, err)
+	}
+
+	// The state file holds the token, so it must be 0600.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("state file perm = %o, want 600", perm)
+	}
+
+	// Clear removes the file.
+	if err := sm2.Clear(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected state file removed after Clear, stat err = %v", err)
+	}
+}
+
+func TestDefaultStateFilePath_EnvOverride(t *testing.T) {
+	t.Setenv("PIPEOPS_STATE_FILE", "/custom/state.yaml")
+	if got := defaultStateFilePath(); got != "/custom/state.yaml" {
+		t.Fatalf("defaultStateFilePath = %q, want /custom/state.yaml", got)
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -314,6 +314,9 @@ type DaemonConfig struct {
 	// AllowedOrigins, when non-empty, restricts which local addresses the daemon
 	// may dial (SSRF guard). Entries are "host:port", bare "host", or "unix:/path".
 	AllowedOrigins []string `yaml:"allowed_origins" mapstructure:"allowed_origins"`
+	// StateFile is where the daemon persists its identity/state (agent id, cluster
+	// token, gateway URL). Empty = $HOME/.pipeops-agent/state.yaml. Written 0600.
+	StateFile string `yaml:"state_file" mapstructure:"state_file"`
 }
 
 // DaemonIngressRule maps a public hostname to a local origin address.


### PR DESCRIPTION
Stacked on #152. Lets a daemon persist its identity across restarts **without Kubernetes** — by reusing the existing token and writing state to a local file instead of a ConfigMap/Secret. No control-plane changes.

## What
- **`state.NewStateManagerWithFile(path)`** — persists `AgentState` (agent id, cluster token, cluster cert, gateway URL) to a local YAML file. `Load`/`Save`/`GetStatePath`/`Clear` branch to the file backend; every getter/setter already routes through `Load`/`Save`, so the entire `StateManager` API works transparently.
  - **Atomic write** (temp + rename), **`0600` perms** (the file holds the cluster token).
  - Default `$HOME/.pipeops-agent/state.yaml`; override via `daemon.state_file` or `PIPEOPS_STATE_FILE`.
- `AgentState` gains `json` tags (the repo's `sigs.k8s.io/yaml` marshals via json tags).
- **`agent.New`** uses the file store when daemon mode is enabled, else the existing ConfigMap/Secret manager.
- `types.DaemonConfig.StateFile`.

## Why this shape
Per the chosen approach: **reuse the existing token + a local file** — smallest change, no new enrollment/credential flow, no control-plane work. A daemon now needs only a token and a config file; it registers once and survives restarts entirely on local state.

## Safety
Only active in daemon mode; cluster mode keeps the exact ConfigMap/Secret behaviour. `go build ./...`, `go vet`, and `go test ./pkg/state ./internal/agent` pass. Test covers round-trip, persistence across a simulated restart, `0600` enforcement, `Clear`, and the env override.

## Remaining (final Phase 3)
- Slim build dropping `client-go` via a build tag (binary size) + packaging (systemd unit, Docker image, `pipeops tunnel run` UX).

> Stacked: #151 ← #152 ← this. Review/merge in order; rebase onto the default branch as each lands.