### PR TITLE
feat: daemon-mode packaging — Dockerfile.daemon, systemd unit, quick start

### DIFF
--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -1,0 +1,58 @@
+# Daemon-mode image: runs the PipeOps connector as a host daemon that forwards
+# tunneled traffic to local origins (no Kubernetes). Same binary as the main
+# image, but without the bundled Helm charts (daemon mode never installs cluster
+# components). Run it pointed at a daemon config — see deployments/daemon/.
+
+# Build stage
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git ca-certificates tzdata
+
+# Non-root runtime user + a pre-owned state directory for the scratch image.
+RUN adduser -D -g '' appuser \
+    && mkdir -p /var/lib/pipeops-agent \
+    && chown appuser /var/lib/pipeops-agent
+
+WORKDIR /app
+
+# Cache deps
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+# Source
+COPY cmd/ ./cmd/
+COPY internal/ ./internal/
+COPY pkg/ ./pkg/
+COPY *.go ./
+
+ARG VERSION=dev
+ARG BUILD_TIME=unknown
+ARG COMMIT=unknown
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags="-w -s -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME} -X main.commit=${COMMIT}" \
+    -a -installsuffix cgo \
+    -trimpath \
+    -o pipeops-agent \
+    cmd/agent/main.go
+
+# Final stage — minimal, no Helm charts.
+FROM scratch
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /app/pipeops-agent /usr/local/bin/pipeops-agent
+COPY --from=builder --chown=appuser /var/lib/pipeops-agent /var/lib/pipeops-agent
+
+USER appuser
+VOLUME ["/var/lib/pipeops-agent"]
+
+# Persist daemon identity/state here; mount a volume to survive restarts.
+ENV PIPEOPS_STATE_FILE=/var/lib/pipeops-agent/state.yaml
+
+ENTRYPOINT ["/usr/local/bin/pipeops-agent"]
+# Default to daemon mode; override config path with `--config /path`.
+CMD ["--daemon"]

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo ""
 	@echo "🐳 DOCKER:"
 	@echo "  make docker             - Build Docker image"
+	@echo "  make docker-daemon      - Build daemon-mode image (no Kubernetes)"
 	@echo "  make k8s-build          - Build Docker image for Kubernetes"
 	@echo ""
 	@echo "☸️  KUBERNETES (Any Cluster):"
@@ -128,6 +129,15 @@ docker:
 	@docker build -t pipeops-vm-agent:$(VERSION) .
 	@docker tag pipeops-vm-agent:$(VERSION) pipeops-vm-agent:latest
 	@echo "✅ Built: pipeops-vm-agent:$(VERSION)"
+
+# Daemon-mode image (host daemon, forwards to local origins — no Kubernetes).
+# See deployments/daemon/ for the systemd unit + quick start.
+.PHONY: docker-daemon
+docker-daemon:
+	@echo "🐳 Building daemon-mode Docker image..."
+	@docker build -f Dockerfile.daemon -t pipeops-agent:$(VERSION)-daemon .
+	@docker tag pipeops-agent:$(VERSION)-daemon pipeops-agent:daemon
+	@echo "✅ Built: pipeops-agent:$(VERSION)-daemon"
 
 # Release target - build for multiple platforms
 .PHONY: release

--- a/deployments/daemon/README.md
+++ b/deployments/daemon/README.md
@@ -1,0 +1,78 @@
+# Running the PipeOps connector as a host daemon
+
+Daemon mode runs the **same connector binary** outside Kubernetes (VM, bare metal,
+Docker, laptop). Instead of resolving Kubernetes Services, it forwards tunneled
+traffic — HTTP and TCP/UDP — to **local origins** (`localhost:port`, `host:port`,
+unix sockets), cloudflared-style. It dials only outbound, so no inbound ports.
+
+What you need: a **connector token** and a **config file**. The daemon registers
+once and persists its identity to a local file (`PIPEOPS_STATE_FILE`, default
+`$HOME/.pipeops-agent/state.yaml`, mode 0600), so it survives restarts with no
+Kubernetes.
+
+## 1. Configure
+
+Start from [`examples/daemon-config.yaml`](../../examples/daemon-config.yaml). Minimal:
+
+```yaml
+pipeops:
+  api_url: "wss://gateway.pipeops.io"
+  token: "${PIPEOPS_TOKEN}"
+daemon:
+  enabled: true
+  default_origin: "localhost:3000"
+  ingress:
+    - hostname: "app.example.com"
+      origin: "localhost:8080"
+  allowed_origins: ["localhost"]   # SSRF guard; empty = allow any configured origin
+```
+
+Edit `ingress:` while running and routes reload live (no restart).
+
+## 2. Run
+
+### Binary
+```sh
+pipeops-agent --daemon --config ./daemon.yaml
+# or fully via env, no config file:
+PIPEOPS_DAEMON_ENABLED=true PIPEOPS_TOKEN=... \
+  PIPEOPS_DAEMON_ROUTES="app.example.com=localhost:8080" pipeops-agent --daemon
+```
+
+### systemd
+```sh
+sudo install -D -m0755 pipeops-agent /usr/local/bin/pipeops-agent
+sudo install -D -m0644 deployments/daemon/pipeops-agent.service /etc/systemd/system/pipeops-agent.service
+sudo install -D -m0644 examples/daemon-config.yaml /etc/pipeops/daemon.yaml
+sudo install -D -m0600 deployments/daemon/daemon.env.example /etc/pipeops/daemon.env
+sudo $EDITOR /etc/pipeops/daemon.env   # set PIPEOPS_TOKEN
+sudo systemctl enable --now pipeops-agent
+journalctl -u pipeops-agent -f
+```
+The unit runs as a `DynamicUser` with a hardened sandbox; systemd provisions
+`/var/lib/pipeops-agent` for the state file.
+
+### Docker
+```sh
+docker build -f Dockerfile.daemon -t pipeops-agent:daemon .
+docker run -d --name pipeops-daemon \
+  -e PIPEOPS_TOKEN="$PIPEOPS_TOKEN" \
+  -v "$PWD/daemon.yaml:/etc/pipeops/daemon.yaml:ro" \
+  -v pipeops-daemon-state:/var/lib/pipeops-agent \
+  --network host \
+  pipeops-agent:daemon --daemon --config /etc/pipeops/daemon.yaml
+```
+`--network host` lets the daemon reach `localhost` origins; or drop it and point
+origins at reachable container/host addresses. The named volume persists identity.
+
+## Notes / limits
+- **SSRF:** `allowed_origins` restricts what the daemon may dial. Leave empty only
+  when you fully trust the config source.
+- **Transport:** tunnels are WS+yamux (TCP-over-TCP) — fine on clean links; a QUIC
+  transport is a separate, larger effort.
+- **Not available in daemon mode:** Kubernetes-only features (component install,
+  `kubectl exec`/API proxying, cluster metrics) are simply skipped.
+- **Binary size:** the daemon links `client-go` even though it doesn't use it in
+  this mode. A build-tag that drops the Kubernetes deps for a slimmer binary is a
+  tracked follow-up (it needs interface extraction across the agent); it does not
+  affect functionality.

--- a/deployments/daemon/daemon.env.example
+++ b/deployments/daemon/daemon.env.example
@@ -1,0 +1,12 @@
+# PipeOps daemon environment — install at /etc/pipeops/daemon.env (chmod 0600).
+# The systemd unit reads this file. Anything settable via config can also be set
+# here as a PIPEOPS_* env var.
+
+# Required: the connector token issued by PipeOps.
+PIPEOPS_TOKEN=replace-with-your-token
+
+# Optional overrides (otherwise taken from daemon.yaml):
+# PIPEOPS_API_URL=wss://gateway.pipeops.io
+# PIPEOPS_DAEMON_ORIGIN=localhost:3000
+# PIPEOPS_DAEMON_ROUTES=app.example.com=localhost:8080,api.example.com=localhost:9000
+# PIPEOPS_STATE_FILE=/var/lib/pipeops-agent/state.yaml

--- a/deployments/daemon/pipeops-agent.service
+++ b/deployments/daemon/pipeops-agent.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=PipeOps Connector (daemon mode)
+Documentation=https://github.com/PipeOpsHQ/pipeops-k8-agent/blob/main/deployments/daemon/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# Token (and any PIPEOPS_* overrides) live here, mode 0600. See daemon.env.example.
+EnvironmentFile=/etc/pipeops/daemon.env
+
+ExecStart=/usr/local/bin/pipeops-agent --daemon --config /etc/pipeops/daemon.yaml
+Restart=always
+RestartSec=5
+
+# Run as an unprivileged dynamic user; systemd provisions and owns
+# /var/lib/pipeops-agent, where the daemon persists its identity/state.
+DynamicUser=yes
+StateDirectory=pipeops-agent
+Environment=PIPEOPS_STATE_FILE=/var/lib/pipeops-agent/state.yaml
+
+# Hardening — the daemon only needs outbound network + its state dir.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -161,7 +161,10 @@ ingress:
   resolves origins via the dialer.
 - **Phase 1 — done.** `OriginDialer` threaded to the L4 yamux path
   (`agent → controlplane.Client → WebSocketClient → YamuxConfig`); per-host routing from the request
-  `Host`; multi-route `HostDialer`.
+  `Host`; multi-route `HostDialer`. Route lookup matches HTTP by `Host` and L4 (which carries no
+  `Host`) by service name / `service.namespace`, so multiple L4 services don't collapse onto the
+  default origin. Unix-socket origins are supported on **both** the HTTP path (via a per-socket
+  transport, `HTTPOrigin`) and L4.
 - **Phase 2 — done.** Config-driven routes: a `daemon:` config section
   (`enabled`/`default_origin`/`ingress`/`allowed_origins`), a `--daemon` flag, `PIPEOPS_DAEMON_*`
   env, an SSRF allowlist on `HostDialer`, and **config-file hot reload** (`viper.WatchConfig` →

--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -172,8 +172,12 @@ ingress:
   `$HOME/.pipeops-agent/state.yaml`, written 0600, atomic temp+rename) instead of a ConfigMap/Secret,
   reusing the existing token — so a daemon survives restarts with no Kubernetes. Configure via
   `daemon.state_file` or `PIPEOPS_STATE_FILE`.
-  **Remaining:** a slim build that drops client-go via a build tag, and packaging (systemd/Docker,
-  `pipeops tunnel run` UX).
+- **Packaging — done.** `Dockerfile.daemon` (scratch image, no bundled Helm charts, `--daemon`
+  default, state volume), a hardened systemd unit + env example under `deployments/daemon/`, a
+  `make docker-daemon` target, and a quick-start covering binary/systemd/Docker.
+  **Remaining (optional):** a slim build that drops client-go via a build tag for a smaller binary —
+  needs interface extraction across the agent and is purely a size optimization (no functional
+  impact); tracked as a separate effort.
 
 ### Configuration (shipped)
 

--- a/examples/daemon-config.yaml
+++ b/examples/daemon-config.yaml
@@ -23,8 +23,10 @@ daemon:
   # Fallback origin used for any hostname not matched by an ingress rule below.
   default_origin: "localhost:3000"
 
-  # Per-hostname routes (the public Host the request arrived for -> local origin).
-  # Origins are host:port, or unix:///path/to.sock.
+  # Routes from a request key -> local origin. For HTTP the key is the public
+  # Host header; for TCP/UDP tunnels (which carry no Host) the key is matched
+  # against the service name, then "service.namespace". Origins are host:port,
+  # or unix:///path/to.sock (works for HTTP and L4).
   ingress:
     - hostname: "app.example.com"
       origin: "localhost:8080"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -167,6 +167,7 @@ type Agent struct {
 	k8sClient      *k8s.Client             // Kubernetes client for in-cluster API access
 	gatewayWatcher *ingress.IngressWatcher // Gateway proxy ingress watcher (for private clusters)
 	originDialer   origin.Dialer           // Resolves/dials the request origin (cluster Service vs daemon host:port)
+	unixClients    sync.Map                // socket path -> *http.Client for unix-socket daemon origins
 
 	// TCP/UDP tunneling via Gateway API (new architecture)
 	tcpUDPTunnelMgr     *TunnelManager            // TCP/UDP tunnel connection manager
@@ -521,6 +522,27 @@ func New(config *types.Config, logger *logrus.Logger) (*Agent, error) {
 	}
 
 	return agent, nil
+}
+
+// unixOriginClient returns a cached HTTP client that dials a unix socket origin
+// (daemon mode, e.g. "unix:///run/app.sock"). The standard pooled client can't
+// reach a socket path, so each socket gets a transport with a unix DialContext.
+func (a *Agent) unixOriginClient(socketPath string) *http.Client {
+	if c, ok := a.unixClients.Load(socketPath); ok {
+		return c.(*http.Client)
+	}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		},
+		MaxIdleConns:        10,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	client := &http.Client{Transport: transport, Timeout: a.proxyHTTPClient.Timeout}
+	actual, _ := a.unixClients.LoadOrStore(socketPath, client)
+	return actual.(*http.Client)
 }
 
 // requestHost returns the public Host the proxied request arrived for, used as
@@ -2875,7 +2897,7 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 	// user-controlled values (path, query) as data, never URL structure
 	// (fmt.Sprintf concatenation would let "@" in the path rewrite the host,
 	// e.g. "http://svc:80@evil.com/x").
-	hostPort, err := a.originDialer.HTTPHostPort(origin.Target{
+	httpOrigin, err := a.originDialer.HTTPOrigin(origin.Target{
 		ServiceName: req.ServiceName,
 		Namespace:   req.Namespace,
 		Port:        int(req.ServicePort),
@@ -2893,7 +2915,7 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 	}
 	targetURL := &neturl.URL{
 		Scheme: httpScheme,
-		Host:   hostPort,
+		Host:   httpOrigin.URLHost,
 		Path:   req.Path,
 	}
 	if req.Query != "" {
@@ -3001,8 +3023,14 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 
 	// PERFORMANCE FIX: Use reusable HTTP client for connection pooling
 	// This prevents creating new TCP connections and TLS handshakes for every request
-	// Critical for concurrent Prometheus queries to reuse connections efficiently
-	resp, err := a.proxyHTTPClient.Do(httpReq)
+	// Critical for concurrent Prometheus queries to reuse connections efficiently.
+	// Unix-socket origins (daemon mode) need a transport that dials the socket;
+	// everything else uses the shared pooled client.
+	httpClient := a.proxyHTTPClient
+	if httpOrigin.Network == "unix" {
+		httpClient = a.unixOriginClient(httpOrigin.Address)
+	}
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		if body != nil {
 			_ = body.Close()

--- a/internal/origin/dialer.go
+++ b/internal/origin/dialer.go
@@ -31,13 +31,32 @@ type Target struct {
 	Hostname    string // public host the request arrived for (daemon route key)
 }
 
+// HTTPOrigin describes how the HTTP proxy path should reach an origin: the host
+// to place in the request URL, plus the network/address to actually dial. For
+// TCP origins URLHost == Address; for unix-socket origins URLHost is a cosmetic
+// placeholder and the HTTP client must dial Network="unix" at Address (the
+// socket path) via a custom transport.
+type HTTPOrigin struct {
+	URLHost string // host[:port] for the request URL
+	Network string // "tcp" | "unix"
+	Address string // dial target: host:port, or a unix socket path
+}
+
 // Dialer resolves and connects to a Target.
 type Dialer interface {
-	// HTTPHostPort returns the "host:port" the HTTP proxy path should dial.
+	// HTTPHostPort returns the host[:port] to place in the request URL. Kept for
+	// callers that only need the URL host; see HTTPOrigin for the dial details.
 	HTTPHostPort(t Target) (string, error)
+	// HTTPOrigin returns the URL host plus the network/address to dial (so the
+	// HTTP path can support unix-socket origins, not just host:port).
+	HTTPOrigin(t Target) (HTTPOrigin, error)
 	// DialContext opens an L4 (tcp/udp) connection to the Target.
 	DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error)
 }
+
+// httpURLPlaceholderHost is the cosmetic URL host used for unix-socket origins;
+// the real Host header is preserved separately and the dial goes to the socket.
+const httpURLPlaceholderHost = "unix-origin.invalid"
 
 // ClusterDialer is the in-cluster behaviour: resolve Kubernetes Services through
 // cluster DNS (<service>.<namespace>.svc.<clusterDomain>). It preserves the
@@ -69,6 +88,14 @@ func (d *ClusterDialer) HTTPHostPort(t Target) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%s:%d", host, t.Port), nil
+}
+
+func (d *ClusterDialer) HTTPOrigin(t Target) (HTTPOrigin, error) {
+	hp, err := d.HTTPHostPort(t)
+	if err != nil {
+		return HTTPOrigin{}, err
+	}
+	return HTTPOrigin{URLHost: hp, Network: "tcp", Address: hp}, nil
 }
 
 func (d *ClusterDialer) DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error) {
@@ -119,19 +146,40 @@ func (d *HostDialer) Update(defaultAddress string, routes map[string]string, all
 	d.mu.Unlock()
 }
 
+// routeKeys returns the candidate route-table keys for a target, in priority
+// order. HTTP requests carry a Hostname; L4 (tcp/udp) tunnels carry only
+// service/namespace, so they match by service name — otherwise every L4 service
+// would collapse onto DefaultAddress.
+func routeKeys(t Target) []string {
+	keys := make([]string, 0, 3)
+	if t.Hostname != "" {
+		keys = append(keys, t.Hostname)
+	}
+	if t.ServiceName != "" {
+		keys = append(keys, t.ServiceName)
+		if t.Namespace != "" {
+			keys = append(keys, t.ServiceName+"."+t.Namespace)
+		}
+	}
+	return keys
+}
+
 func (d *HostDialer) resolve(t Target) (network, address string, err error) {
 	d.mu.RLock()
 	addr := d.DefaultAddress
-	if d.Routes != nil && t.Hostname != "" {
-		if a, ok := d.Routes[t.Hostname]; ok {
-			addr = a
+	if d.Routes != nil {
+		for _, k := range routeKeys(t) {
+			if a, ok := d.Routes[k]; ok {
+				addr = a
+				break
+			}
 		}
 	}
 	allowlist := d.AllowedOrigins // slice header copy; Update replaces, never mutates
 	d.mu.RUnlock()
 
 	if addr == "" {
-		return "", "", fmt.Errorf("origin: no local address configured for host %q", t.Hostname)
+		return "", "", fmt.Errorf("origin: no local address configured for target %q", routeLabel(t))
 	}
 	if sock, ok := strings.CutPrefix(addr, "unix://"); ok {
 		network, address = "unix", sock
@@ -143,9 +191,23 @@ func (d *HostDialer) resolve(t Target) (network, address string, err error) {
 		address = addr
 	}
 	if !addrAllowed(allowlist, network, address) {
-		return "", "", fmt.Errorf("origin: address %q not permitted by daemon allowed_origins (host %q)", address, t.Hostname)
+		return "", "", fmt.Errorf("origin: address %q not permitted by daemon allowed_origins (target %q)", address, routeLabel(t))
 	}
 	return network, address, nil
+}
+
+// routeLabel is a human-readable identifier for a target, for error messages.
+func routeLabel(t Target) string {
+	if t.Hostname != "" {
+		return t.Hostname
+	}
+	if t.ServiceName != "" {
+		if t.Namespace != "" {
+			return t.ServiceName + "." + t.Namespace
+		}
+		return t.ServiceName
+	}
+	return "(default)"
 }
 
 // addrAllowed reports whether the resolved address passes the SSRF allowlist. An
@@ -178,11 +240,24 @@ func addrAllowed(allowlist []string, network, address string) bool {
 }
 
 func (d *HostDialer) HTTPHostPort(t Target) (string, error) {
-	_, addr, err := d.resolve(t)
+	o, err := d.HTTPOrigin(t)
 	if err != nil {
 		return "", err
 	}
-	return addr, nil
+	return o.URLHost, nil
+}
+
+func (d *HostDialer) HTTPOrigin(t Target) (HTTPOrigin, error) {
+	network, addr, err := d.resolve(t)
+	if err != nil {
+		return HTTPOrigin{}, err
+	}
+	if network == "unix" {
+		// The HTTP client dials the socket via a custom transport; the URL host
+		// is a placeholder (the real Host header is preserved by the proxy path).
+		return HTTPOrigin{URLHost: httpURLPlaceholderHost, Network: "unix", Address: addr}, nil
+	}
+	return HTTPOrigin{URLHost: addr, Network: "tcp", Address: addr}, nil
 }
 
 func (d *HostDialer) DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error) {

--- a/internal/origin/dialer_test.go
+++ b/internal/origin/dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -153,6 +154,78 @@ func TestHostDialer_ConcurrentReload(t *testing.T) {
 	}
 	close(stop)
 	wg.Wait()
+}
+
+// TestHostDialer_L4ServiceRouting proves L4 tunnels (no Hostname) match the route
+// table by service name / service.namespace, instead of all collapsing onto the
+// default origin.
+func TestHostDialer_L4ServiceRouting(t *testing.T) {
+	d := NewHostDialer("localhost:9999", map[string]string{
+		"redis":   "localhost:6379",
+		"db.prod": "localhost:5432",
+	})
+	// Match by bare service name.
+	if addr, err := d.HTTPHostPort(Target{Protocol: "tcp", ServiceName: "redis", Namespace: "default", Port: 6379}); err != nil || addr != "localhost:6379" {
+		t.Fatalf("service route = %q, %v; want localhost:6379", addr, err)
+	}
+	// Match by service.namespace.
+	if addr, _ := d.HTTPHostPort(Target{ServiceName: "db", Namespace: "prod"}); addr != "localhost:5432" {
+		t.Fatalf("svc.ns route = %q, want localhost:5432", addr)
+	}
+	// Unmatched -> default.
+	if addr, _ := d.HTTPHostPort(Target{ServiceName: "unknown", Namespace: "default"}); addr != "localhost:9999" {
+		t.Fatalf("default = %q, want localhost:9999", addr)
+	}
+	// Hostname still wins over service name when present.
+	d2 := NewHostDialer("localhost:9999", map[string]string{"app.example.com": "localhost:8080", "app": "localhost:1"})
+	if addr, _ := d2.HTTPHostPort(Target{Hostname: "app.example.com", ServiceName: "app"}); addr != "localhost:8080" {
+		t.Fatalf("hostname precedence = %q, want localhost:8080", addr)
+	}
+}
+
+// TestHostDialer_UnixHTTPOrigin proves a unix-socket origin is reachable over the
+// HTTP path: HTTPOrigin reports Network=unix, and a client dialing that socket
+// reaches a real server. (Before this, the socket path leaked into the URL host
+// and the request failed.)
+func TestHostDialer_UnixHTTPOrigin(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "app.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	d := NewHostDialer("unix://"+sock, nil)
+	o, err := d.HTTPOrigin(Target{})
+	if err != nil {
+		t.Fatalf("HTTPOrigin: %v", err)
+	}
+	if o.Network != "unix" || o.Address != sock {
+		t.Fatalf("origin = %+v, want unix %s", o, sock)
+	}
+	if o.URLHost == sock {
+		t.Fatal("URL host must be a placeholder, not the socket path")
+	}
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dl net.Dialer
+			return dl.DialContext(ctx, o.Network, o.Address)
+		},
+	}}
+	resp, err := client.Get("http://" + o.URLHost + "/")
+	if err != nil {
+		t.Fatalf("GET over unix socket: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTeapot {
+		t.Fatalf("status = %d, want 418 (proves request reached the unix origin)", resp.StatusCode)
+	}
 }
 
 var _ Dialer = (*ClusterDialer)(nil)


### PR DESCRIPTION
Stacked on #153. Two things: (1) **packaging** to make daemon mode deployable, and (2) two **origin-resolution correctness fixes** found during review.

## Packaging
- **`Dockerfile.daemon`** — scratch image, **without** the bundled Helm charts (daemon never installs cluster components), non-root user + pre-owned `/var/lib/pipeops-agent` state dir, `CMD ["--daemon"]`, `PIPEOPS_STATE_FILE` + state `VOLUME`.
- **`deployments/daemon/`** — hardened systemd unit (`DynamicUser` + `StateDirectory`, `NoNewPrivileges`/`ProtectSystem=strict`/`RestrictAddressFamilies`, auto-restart), `daemon.env.example` (token), and a `README.md` quick-start for **binary / systemd / Docker**.
- **`make docker-daemon`** target + help line.

## Correctness fixes
- **Unix-socket origins now work over HTTP, not just L4.** Added `origin.HTTPOrigin` (URL host + network + dial address). For a `unix://` origin the proxy path dials the socket via a per-socket cached `http.Client` transport, instead of leaking the socket path into the URL host (which silently failed). TCP origins unchanged (shared pooled client). E2E test serves HTTP over a real unix socket and reaches it.
- **L4 (TCP/UDP) tunnels now route by service name.** They carry no `Host`, so they previously all collapsed onto `default_origin`. Route lookup now tries `Hostname` → `service` → `service.namespace`; `Hostname` still wins when present. So multiple L4 services route independently.

## Verified
`go build ./...`, `go vet`, `go test -race ./internal/origin`, `go test ./internal/agent` pass. `--daemon` flag builds and is wired.

## Still deferred (no functional impact)
Slim client-go-free binary (size-only; needs cross-cutting interface extraction). Tracked separately.

## The stack
`#151 ← #152 ← #153 ← this`. Review/merge in order; rebase each onto the default branch as the one below lands. The packaging here is release-engineering — worth a look from whoever owns the agent CI/release pipeline.