### PR TITLE
feat(daemon): per-route origin scheme + origin dial metrics

### DIFF
--- a/docs/daemon-mode-design.md
+++ b/docs/daemon-mode-design.md
@@ -164,7 +164,9 @@ ingress:
   `Host`; multi-route `HostDialer`. Route lookup matches HTTP by `Host` and L4 (which carries no
   `Host`) by service name / `service.namespace`, so multiple L4 services don't collapse onto the
   default origin. Unix-socket origins are supported on **both** the HTTP path (via a per-socket
-  transport, `HTTPOrigin`) and L4.
+  transport, `HTTPOrigin`) and L4. A route may also pin the origin scheme (`https://localhost:8443`)
+  to reach a local TLS service, overriding the request scheme. Daemon origin outcomes are exported
+  as the `pipeops_agent_daemon_origin_requests_total{network,result}` metric.
 - **Phase 2 — done.** Config-driven routes: a `daemon:` config section
   (`enabled`/`default_origin`/`ingress`/`allowed_origins`), a `--daemon` flag, `PIPEOPS_DAEMON_*`
   env, an SSRF allowlist on `HostDialer`, and **config-file hot reload** (`viper.WatchConfig` →

--- a/examples/daemon-config.yaml
+++ b/examples/daemon-config.yaml
@@ -32,6 +32,9 @@ daemon:
       origin: "localhost:8080"
     - hostname: "api.example.com"
       origin: "localhost:9000"
+    # Pin a scheme to reach a local TLS origin (otherwise the request scheme is used).
+    - hostname: "secure.example.com"
+      origin: "https://localhost:8443"
     - hostname: "db.example.com"
       origin: "unix:///run/postgres.sock"
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -545,6 +545,17 @@ func (a *Agent) unixOriginClient(socketPath string) *http.Client {
 	return actual.(*http.Client)
 }
 
+// recordDaemonOrigin records an origin request outcome, but only in daemon mode
+// (when the dialer is a HostDialer). Cheap type assertion keeps the hot path clean.
+func (a *Agent) recordDaemonOrigin(network, result string) {
+	if a.metrics == nil {
+		return
+	}
+	if _, ok := a.originDialer.(*origin.HostDialer); ok {
+		a.metrics.recordDaemonOriginRequest(network, result)
+	}
+}
+
 // requestHost returns the public Host the proxied request arrived for, used as
 // the per-host routing key in daemon mode. Checks the Host header (the gateway
 // forwards the original Host); empty when absent.
@@ -2904,6 +2915,7 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 		Hostname:    requestHost(req),
 	})
 	if err != nil {
+		a.recordDaemonOrigin("", "resolve_error")
 		if body != nil {
 			_ = body.Close()
 		}
@@ -2912,6 +2924,11 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 	httpScheme := "http"
 	if req.Scheme == "https" {
 		httpScheme = "https"
+	}
+	// A daemon route may pin the local origin's scheme (e.g. https://localhost:8443),
+	// overriding the request scheme.
+	if httpOrigin.Scheme != "" {
+		httpScheme = httpOrigin.Scheme
 	}
 	targetURL := &neturl.URL{
 		Scheme: httpScheme,
@@ -3032,12 +3049,14 @@ func (a *Agent) proxyToService(ctx context.Context, req *controlplane.ProxyReque
 	}
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
+		a.recordDaemonOrigin(httpOrigin.Network, "dial_error")
 		if body != nil {
 			_ = body.Close()
 		}
 		logger.WithError(err).Error("Failed to proxy request to service")
 		return 0, nil, nil, fmt.Errorf("service request failed: %w", err)
 	}
+	a.recordDaemonOrigin(httpOrigin.Network, "ok")
 
 	logger.WithField("status_code", resp.StatusCode).Debug("Service proxy request completed")
 

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -56,6 +56,9 @@ type Metrics struct {
 	gatewayWatcherDiscoveredServices prometheus.Gauge
 	gatewayWatcherRegistrationErrors prometheus.Counter
 	gatewayWatcherSyncTotal          prometheus.Counter
+
+	// Daemon-mode origin resolution/dial outcomes (labels: network, result)
+	daemonOriginRequests *prometheus.CounterVec
 }
 
 // newMetrics creates and registers all agent metrics
@@ -225,6 +228,13 @@ func newMetrics() *Metrics {
 			Name: "pipeops_agent_gateway_watcher_sync_total",
 			Help: "Total number of gateway watcher sync operations",
 		}),
+		daemonOriginRequests: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "pipeops_agent_daemon_origin_requests_total",
+				Help: "Daemon-mode origin requests by dial network and result (ok, resolve_error, dial_error)",
+			},
+			[]string{"network", "result"},
+		),
 
 		lastStateChange: time.Now(),
 	}
@@ -378,6 +388,16 @@ func (m *Metrics) recordTCPTunnelBytesReceived(bytes int64) {
 // recordTCPTunnelError records TCP tunnel errors
 func (m *Metrics) recordTCPTunnelError(errorType string) {
 	m.tcpTunnelConnectionErrors.WithLabelValues(errorType).Inc()
+}
+
+// recordDaemonOriginRequest records a daemon-mode origin request outcome.
+// network is "tcp"|"unix" (or "" when resolution failed before a network was
+// known); result is "ok"|"resolve_error"|"dial_error".
+func (m *Metrics) recordDaemonOriginRequest(network, result string) {
+	if network == "" {
+		network = "unknown"
+	}
+	m.daemonOriginRequests.WithLabelValues(network, result).Inc()
 }
 
 // UDP Tunnel Metrics

--- a/internal/origin/dialer.go
+++ b/internal/origin/dialer.go
@@ -195,6 +195,11 @@ func (d *HostDialer) resolve(t Target) (network, address, scheme string, err err
 		case strings.HasPrefix(addr, "http://"):
 			scheme, addr = "http", strings.TrimPrefix(addr, "http://")
 		}
+		// Reject scheme-only ("https://") or path-bearing ("host:port/x") origins
+		// here with a clear message, instead of failing opaquely at dial time.
+		if addr == "" || strings.Contains(addr, "/") {
+			return "", "", "", fmt.Errorf("origin: malformed origin for target %q: want host:port, http(s)://host:port, or unix:///path", routeLabel(t))
+		}
 		network = t.Protocol
 		if network == "" {
 			network = "tcp"

--- a/internal/origin/dialer.go
+++ b/internal/origin/dialer.go
@@ -40,6 +40,7 @@ type HTTPOrigin struct {
 	URLHost string // host[:port] for the request URL
 	Network string // "tcp" | "unix"
 	Address string // dial target: host:port, or a unix socket path
+	Scheme  string // "http"|"https" when the route pinned one; "" = use request scheme
 }
 
 // Dialer resolves and connects to a Target.
@@ -164,7 +165,9 @@ func routeKeys(t Target) []string {
 	return keys
 }
 
-func (d *HostDialer) resolve(t Target) (network, address string, err error) {
+// resolve maps a Target to a dial network+address, plus an optional HTTP scheme
+// when the configured origin carried one (e.g. "https://localhost:8443").
+func (d *HostDialer) resolve(t Target) (network, address, scheme string, err error) {
 	d.mu.RLock()
 	addr := d.DefaultAddress
 	if d.Routes != nil {
@@ -179,11 +182,19 @@ func (d *HostDialer) resolve(t Target) (network, address string, err error) {
 	d.mu.RUnlock()
 
 	if addr == "" {
-		return "", "", fmt.Errorf("origin: no local address configured for target %q", routeLabel(t))
+		return "", "", "", fmt.Errorf("origin: no local address configured for target %q", routeLabel(t))
 	}
 	if sock, ok := strings.CutPrefix(addr, "unix://"); ok {
 		network, address = "unix", sock
 	} else {
+		// Optional scheme prefix lets a route pin a local origin as http/https
+		// (otherwise the request's own scheme is used).
+		switch {
+		case strings.HasPrefix(addr, "https://"):
+			scheme, addr = "https", strings.TrimPrefix(addr, "https://")
+		case strings.HasPrefix(addr, "http://"):
+			scheme, addr = "http", strings.TrimPrefix(addr, "http://")
+		}
 		network = t.Protocol
 		if network == "" {
 			network = "tcp"
@@ -191,9 +202,9 @@ func (d *HostDialer) resolve(t Target) (network, address string, err error) {
 		address = addr
 	}
 	if !addrAllowed(allowlist, network, address) {
-		return "", "", fmt.Errorf("origin: address %q not permitted by daemon allowed_origins (target %q)", address, routeLabel(t))
+		return "", "", "", fmt.Errorf("origin: address %q not permitted by daemon allowed_origins (target %q)", address, routeLabel(t))
 	}
-	return network, address, nil
+	return network, address, scheme, nil
 }
 
 // routeLabel is a human-readable identifier for a target, for error messages.
@@ -248,20 +259,20 @@ func (d *HostDialer) HTTPHostPort(t Target) (string, error) {
 }
 
 func (d *HostDialer) HTTPOrigin(t Target) (HTTPOrigin, error) {
-	network, addr, err := d.resolve(t)
+	network, addr, scheme, err := d.resolve(t)
 	if err != nil {
 		return HTTPOrigin{}, err
 	}
 	if network == "unix" {
 		// The HTTP client dials the socket via a custom transport; the URL host
 		// is a placeholder (the real Host header is preserved by the proxy path).
-		return HTTPOrigin{URLHost: httpURLPlaceholderHost, Network: "unix", Address: addr}, nil
+		return HTTPOrigin{URLHost: httpURLPlaceholderHost, Network: "unix", Address: addr, Scheme: scheme}, nil
 	}
-	return HTTPOrigin{URLHost: addr, Network: "tcp", Address: addr}, nil
+	return HTTPOrigin{URLHost: addr, Network: "tcp", Address: addr, Scheme: scheme}, nil
 }
 
 func (d *HostDialer) DialContext(ctx context.Context, t Target, timeout time.Duration) (net.Conn, error) {
-	network, addr, err := d.resolve(t)
+	network, addr, _, err := d.resolve(t)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/origin/dialer_test.go
+++ b/internal/origin/dialer_test.go
@@ -257,6 +257,24 @@ func TestHostDialer_OriginScheme(t *testing.T) {
 	}
 }
 
+// TestHostDialer_MalformedOrigin proves bad origins fail at resolution with a
+// clear error, not opaquely at dial time.
+func TestHostDialer_MalformedOrigin(t *testing.T) {
+	for _, bad := range []string{"https://", "http://", "https://localhost:8443/base", "localhost:8080/x"} {
+		d := NewHostDialer(bad, nil)
+		if _, err := d.HTTPOrigin(Target{}); err == nil {
+			t.Fatalf("origin %q should be rejected as malformed", bad)
+		}
+	}
+	// Sanity: the valid forms still resolve.
+	for _, good := range []string{"localhost:8080", "https://localhost:8443", "unix:///run/app.sock"} {
+		d := NewHostDialer(good, nil)
+		if _, err := d.HTTPOrigin(Target{}); err != nil {
+			t.Fatalf("origin %q should be valid, got %v", good, err)
+		}
+	}
+}
+
 var _ Dialer = (*ClusterDialer)(nil)
 var _ Dialer = (*HostDialer)(nil)
 var _ net.Conn = nil

--- a/internal/origin/dialer_test.go
+++ b/internal/origin/dialer_test.go
@@ -228,6 +228,35 @@ func TestHostDialer_UnixHTTPOrigin(t *testing.T) {
 	}
 }
 
+// TestHostDialer_OriginScheme proves a route can pin the local origin scheme
+// (http/https), and that the dial address has the scheme stripped.
+func TestHostDialer_OriginScheme(t *testing.T) {
+	d := NewHostDialer("localhost:3000", map[string]string{
+		"secure.example.com": "https://localhost:8443",
+		"plain.example.com":  "http://localhost:8080",
+		"bare.example.com":   "localhost:9090",
+	})
+
+	o, _ := d.HTTPOrigin(Target{Hostname: "secure.example.com"})
+	if o.Scheme != "https" || o.URLHost != "localhost:8443" || o.Address != "localhost:8443" {
+		t.Fatalf("https origin = %+v", o)
+	}
+	o2, _ := d.HTTPOrigin(Target{Hostname: "plain.example.com"})
+	if o2.Scheme != "http" || o2.Address != "localhost:8080" {
+		t.Fatalf("http origin = %+v", o2)
+	}
+	// Bare origin pins no scheme (caller falls back to the request scheme).
+	o3, _ := d.HTTPOrigin(Target{Hostname: "bare.example.com"})
+	if o3.Scheme != "" || o3.Address != "localhost:9090" {
+		t.Fatalf("bare origin = %+v", o3)
+	}
+	// Scheme is stripped before the SSRF allowlist check (allowlist holds host:port).
+	d.AllowedOrigins = []string{"localhost:8443"}
+	if _, err := d.HTTPOrigin(Target{Hostname: "secure.example.com"}); err != nil {
+		t.Fatalf("allowlist should match stripped address: %v", err)
+	}
+}
+
 var _ Dialer = (*ClusterDialer)(nil)
 var _ Dialer = (*HostDialer)(nil)
 var _ net.Conn = nil


### PR DESCRIPTION
Stacked on #154. Two daemon-mode refinements from the follow-up list.

## Per-route origin scheme
A daemon route origin may now carry a scheme:
```yaml
ingress:
  - hostname: "secure.example.com"
    origin: "https://localhost:8443"   # reach a local TLS service
```
`origin.HTTPOrigin` gains `Scheme`; `resolve()` strips `http://`/`https://` **before** the SSRF allowlist check and the dial (the allowlist still matches on `host:port`). When a route pins a scheme it overrides the request scheme; bare `host:port` and `unix://` are unchanged.

## Origin dial metrics
New counter `pipeops_agent_daemon_origin_requests_total{network,result}` (`network` = tcp/unix, `result` = ok/resolve_error/dial_error), recorded on the HTTP proxy path and **gated to daemon mode** (no-op type-assertion in cluster mode). Gives operators visibility into which origins resolve and dial.

## Verified
`go build ./...`, `go vet`, `go test ./internal/{origin,agent}` pass. New tests cover scheme parsing + allowlist-after-strip.

## The stack
`#151 ← #152 ← #153 ← #154 ← this`. The remaining follow-up — a slim client-go-free binary — is tracked separately (size-only; needs cross-cutting interface extraction).