### PR TITLE
fix(auth): prefer Authorization Bearer over query token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,3 +243,8 @@ GitHub Actions (`.github/workflows/ci.yml`): test (race + coverage + golangci-li
 make docker               # Build production image (multi-stage: golang:1.24-alpine -> scratch)
 docker compose up         # Dev environment with live reload (Air)
 ```
+
+## Control plane authentication
+
+Always send the PipeOps agent token as `Authorization: Bearer <token>`.
+Do **not** put the token in URL query parameters (`?token=`).

--- a/internal/controlplane/auth.go
+++ b/internal/controlplane/auth.go
@@ -1,0 +1,18 @@
+package controlplane
+
+import (
+	"net/http"
+
+	"github.com/pipeops/pipeops-vm-agent/pkg/auth"
+)
+
+// AuthHeader builds Authorization: Bearer for control-plane / gateway dials.
+// Prefer Bearer; never put the agent token in ?token= query strings.
+func AuthHeader(token string) http.Header {
+	return auth.BearerHeader(token)
+}
+
+// ApplyAuthHeader sets Authorization: Bearer on h.
+func ApplyAuthHeader(h http.Header, token string) {
+	auth.SetBearer(h, token)
+}

--- a/internal/controlplane/auth_test.go
+++ b/internal/controlplane/auth_test.go
@@ -1,0 +1,28 @@
+package controlplane
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestApplyAuthHeader_BearerOnly(t *testing.T) {
+	h := make(http.Header)
+	ApplyAuthHeader(h, "sat_test_token")
+	if got := h.Get("Authorization"); got != "Bearer sat_test_token" {
+		t.Fatalf("Authorization=%q", got)
+	}
+}
+
+func TestApplyAuthHeader_StripsExistingBearer(t *testing.T) {
+	h := AuthHeader("Bearer already")
+	if got := h.Get("Authorization"); got != "Bearer already" {
+		t.Fatalf("Authorization=%q", got)
+	}
+}
+
+func TestApplyAuthHeader_Empty(t *testing.T) {
+	h := AuthHeader("  ")
+	if h.Get("Authorization") != "" {
+		t.Fatal("expected empty header for empty token")
+	}
+}

--- a/internal/controlplane/websocket_client.go
+++ b/internal/controlplane/websocket_client.go
@@ -294,9 +294,8 @@ func (c *WebSocketClient) ConnectToGateway() error {
 		}
 	}
 
-	// Use Authorization header for token (more secure than query params)
-	headers := make(map[string][]string)
-	headers["Authorization"] = []string{"Bearer " + c.token}
+	// Prefer Authorization: Bearer (never put token in query params).
+	headers := AuthHeader(c.token)
 
 	conn, resp, err := dialer.Dial(u.String(), headers)
 	if err != nil {
@@ -465,10 +464,9 @@ func (c *WebSocketClient) Connect() error {
 		}
 	}
 
-	// Use Authorization header for authentication (more secure than query params)
-	// Query params can be logged by proxies and appear in server access logs
-	headers := make(map[string][]string)
-	headers["Authorization"] = []string{"Bearer " + c.token}
+	// Prefer Authorization: Bearer (never put token in query params —
+	// query tokens can be logged by proxies and appear in access logs).
+	headers := AuthHeader(c.token)
 
 	conn, resp, err := dialer.Dial(u.String(), headers)
 	if err != nil {

--- a/internal/ingress/client.go
+++ b/internal/ingress/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pipeops/pipeops-vm-agent/pkg/auth"
 	"github.com/sirupsen/logrus"
 )
 
@@ -111,7 +112,8 @@ func (c *ControllerClient) doRequest(ctx context.Context, method, urlStr string,
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.agentToken)
+	// Prefer Authorization: Bearer (never put agent token in ?token=).
+	auth.SetBearer(req.Header, c.agentToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/tunnel/control_plane_client.go
+++ b/internal/tunnel/control_plane_client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pipeops/pipeops-vm-agent/pkg/auth"
 	"github.com/sirupsen/logrus"
 )
 
@@ -63,7 +64,7 @@ func (c *HTTPControlPlaneClient) RegisterTunnel(ctx context.Context, req *Tunnel
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	auth.SetBearer(httpReq.Header, c.token)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -99,7 +100,7 @@ func (c *HTTPControlPlaneClient) SyncTunnels(ctx context.Context, req *TunnelSyn
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	auth.SetBearer(httpReq.Header, c.token)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -129,7 +130,7 @@ func (c *HTTPControlPlaneClient) DeregisterTunnel(ctx context.Context, clusterUU
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	auth.SetBearer(httpReq.Header, c.token)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -154,7 +155,7 @@ func (c *HTTPControlPlaneClient) ListTunnels(ctx context.Context, clusterUUID st
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	auth.SetBearer(httpReq.Header, c.token)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {

--- a/pkg/auth/header.go
+++ b/pkg/auth/header.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// BearerHeader returns Authorization: Bearer <token>.
+// Prefer this over putting tokens in URL query strings (?token=).
+// The control plane accepts query tokens for legacy agents; new code must use Bearer.
+func BearerHeader(token string) http.Header {
+	h := make(http.Header)
+	SetBearer(h, token)
+	return h
+}
+
+// SetBearer sets Authorization: Bearer on h.
+func SetBearer(h http.Header, token string) {
+	if h == nil {
+		return
+	}
+	t := strings.TrimSpace(token)
+	if t == "" {
+		return
+	}
+	t = strings.TrimSpace(strings.TrimPrefix(t, "Bearer "))
+	t = strings.TrimSpace(strings.TrimPrefix(t, "bearer "))
+	h.Set("Authorization", fmt.Sprintf("Bearer %s", t))
+}

--- a/pkg/auth/header_test.go
+++ b/pkg/auth/header_test.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetBearer(t *testing.T) {
+	h := make(http.Header)
+	SetBearer(h, "sat_abc")
+	if got := h.Get("Authorization"); got != "Bearer sat_abc" {
+		t.Fatalf("Authorization=%q", got)
+	}
+}
+
+func TestSetBearer_StripsPrefix(t *testing.T) {
+	h := make(http.Header)
+	SetBearer(h, "Bearer already")
+	if got := h.Get("Authorization"); got != "Bearer already" {
+		t.Fatalf("Authorization=%q", got)
+	}
+}
+
+func TestBearerHeader_Empty(t *testing.T) {
+	h := BearerHeader("  ")
+	if h.Get("Authorization") != "" {
+		t.Fatal("expected empty Authorization for blank token")
+	}
+}
+
+func TestSetBearer_NilHeader(t *testing.T) {
+	// must not panic
+	SetBearer(nil, "token")
+}


### PR DESCRIPTION
## Summary
- Add `pkg/auth` (`BearerHeader` / `SetBearer`) and controlplane `AuthHeader` wrappers so agent→control-plane auth is always `Authorization: Bearer`.
- Wire WebSocket dials, tunnel HTTP client, and ingress controller client through the helper.
- Document in `AGENTS.md`: never put the PipeOps token in `?token=` query strings.

## Why
Query tokens can land in proxy/access logs. The controller continues to accept `?token=` for **legacy** agents (non-breaking), but this agent should prefer Bearer so we can deprecate query auth safely over time.

## Test plan
- [x] `go test ./pkg/auth/... ./internal/controlplane/ ./internal/tunnel/ ./internal/ingress/`
- [x] `go build ./...`
- [ ] CI green
- [ ] Spot-check WS connect / tunnel register still send `Authorization: Bearer` only (no `token` query param)